### PR TITLE
add CLI for orthographic camera

### DIFF
--- a/zndraw/cli.py
+++ b/zndraw/cli.py
@@ -28,6 +28,9 @@ def main(
     browser: bool = typer.Option(True, help="Open the browser automatically."),
     webview: bool = typer.Option(True, help="Use the webview library if available."),
     verbose: bool = typer.Option(False, help="Run the server in verbose mode."),
+    camera: str = typer.Option(
+        "PerspectiveCamera", help="Either PerspectiveCamera or OrthographicCamera"
+    ),
 ):
     """ZnDraw: Visualize Molecules
 
@@ -53,7 +56,7 @@ def main(
         typer.echo(f"File {file} does not exist.")
         raise typer.Exit()
 
-    globals.config = globals.Config(file=file)
+    globals.config = globals.Config(file=file, camera=camera)
     print(globals.config)
 
     if wv is not None and webview:

--- a/zndraw/globals.py
+++ b/zndraw/globals.py
@@ -1,4 +1,5 @@
 import dataclasses
+import enum
 import importlib
 import pathlib
 import typing
@@ -10,8 +11,16 @@ import znh5md
 from pydantic import BaseModel, Field, PrivateAttr
 
 
+class CameraChoices(str, enum.Enum):
+    OrthographicCamera = "OrthographicCamera"
+    PerspectiveCamera = "PerspectiveCamera"
+
+
 class Config(BaseModel):
     file: str = Field(..., description="Trajectory File")
+    camera: CameraChoices = Field(
+        CameraChoices.PerspectiveCamera, description="Camera style"
+    )
     bond_size: float = Field(1.0, description="Bond Size")
     sphere_size: float = Field(1.0, description="Sphere Size")
     resolution: int = Field(10, description="Resolution")

--- a/zndraw/static/main.js
+++ b/zndraw/static/main.js
@@ -4,6 +4,7 @@ import * as PARTICLES from './modules/particles.js';
 import * as DRAW from './modules/draw.js';
 import * as DATA from './modules/data.js';
 import { keydown, keyconfig } from './modules/keypress.js';
+import { config } from './modules/data.js';
 // THREE.Cache.enabled = true;
 
 
@@ -47,7 +48,21 @@ const addSceneModifier = document.getElementById("addSceneModifier");
 await DATA.load_config();
 // THREE JS Setup
 const scene = new THREE.Scene();
-const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+
+function getCamera(){
+	let width = window.innerWidth;
+	let height = window.innerHeight;
+
+	if (config.camera == "PerspectiveCamera"){
+		return new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+	} else {
+		return new THREE.OrthographicCamera( width / - 2, width / 2, height / 2, height / - 2, 1, 1000 );
+	}
+}
+
+const camera = getCamera();
+camera.position.z = 50;
+
 const renderer = new THREE.WebGLRenderer({ antialias: DATA.config["antialias"], alpha: true });
 
 const hemisphereLight = new THREE.HemisphereLight(0xffffff, 0x777777, 0.1);
@@ -110,7 +125,6 @@ build_scene(0);
 
 // interactions
 
-camera.position.z = 50;
 const controls = new OrbitControls(camera, renderer.domElement);
 
 controls.update();


### PR DESCRIPTION
It is difficult to switch the camera in THREE.js so I added a CLI / config option to select the orthographic camera.
Eventually, I'll look at this again but for now this fixes parts of https://github.com/zincware/ZnDraw/issues/49 