### PR TITLE
save modifiers in a private dict in the config

### DIFF
--- a/zndraw/app.py
+++ b/zndraw/app.py
@@ -203,6 +203,7 @@ def frame_stream():
 
     return Response(generate(session["step"]), mimetype="text/event-stream")
 
+
 @app.route("/reset-scene-modifiers")
 def reset_scene_modifiers():
     shared.config.reset_scene_modifiers()

--- a/zndraw/app.py
+++ b/zndraw/app.py
@@ -202,3 +202,8 @@ def frame_stream():
         yield f"data: {json.dumps({})} \nretry: 10\n\n"
 
     return Response(generate(session["step"]), mimetype="text/event-stream")
+
+@app.route("/reset-scene-modifiers")
+def reset_scene_modifiers():
+    shared.config.reset_scene_modifiers()
+    return {}

--- a/zndraw/shared.py
+++ b/zndraw/shared.py
@@ -119,7 +119,7 @@ class Config(BaseModel):
 
     def reset_scene_modifiers(self) -> None:
         """Reset the scene modifiers."""
-        for key in self._atoms_cache:
+        for key in list(self._atoms_cache):
             del self._atoms_cache[key]
         self._loaded_modifiers = {}
 

--- a/zndraw/shared.py
+++ b/zndraw/shared.py
@@ -116,6 +116,12 @@ class Config(BaseModel):
 
         for idx, atom in enumerate(atoms):
             self._atoms_cache[idx + step + 1] = atom
+    
+    def reset_scene_modifiers(self) -> None:
+        """Reset the scene modifiers."""
+        for key in self._atoms_cache:
+            del self._atoms_cache[key]
+        self._loaded_modifiers = {}
 
     def export_atoms(self):
         file = io.BytesIO()

--- a/zndraw/shared.py
+++ b/zndraw/shared.py
@@ -58,7 +58,7 @@ class Config(BaseModel):
     selection_functions: typing.List[str] = _SELECTION_FUNCTIONS
     bonds_functions: typing.List[str] = _BONDS_FUNCTIONS
     js_frame_buffer: tuple = Field(
-        (2, 2), description="Javascript frame buffer in negative/positive direction"
+        (50, 50), description="Javascript frame buffer in negative/positive direction"
     )
     _atoms_cache = PrivateAttr(default_factory=dict)
     _loaded_modifiers: typing.Dict[str, typing.Any] = PrivateAttr(default_factory=dict)

--- a/zndraw/shared.py
+++ b/zndraw/shared.py
@@ -116,7 +116,7 @@ class Config(BaseModel):
 
         for idx, atom in enumerate(atoms):
             self._atoms_cache[idx + step + 1] = atom
-    
+
     def reset_scene_modifiers(self) -> None:
         """Reset the scene modifiers."""
         for key in self._atoms_cache:

--- a/zndraw/shared.py
+++ b/zndraw/shared.py
@@ -58,10 +58,10 @@ class Config(BaseModel):
     selection_functions: typing.List[str] = _SELECTION_FUNCTIONS
     bonds_functions: typing.List[str] = _BONDS_FUNCTIONS
     js_frame_buffer: tuple = Field(
-        (50, 200), description="Javascript frame buffer in negative/positive direction"
+        (2, 2), description="Javascript frame buffer in negative/positive direction"
     )
-
     _atoms_cache = PrivateAttr(default_factory=dict)
+    _loaded_modifiers: typing.Dict[str, typing.Any] = PrivateAttr(default_factory=dict)
     _modifier_applied: bool = PrivateAttr(False)
 
     def get_modifier_schema(self, update_function) -> dict:
@@ -100,10 +100,14 @@ class Config(BaseModel):
         Save the updated atoms in the cache.
         """
         self._modifier_applied = True
-        module_name, function_name = modifier.rsplit(".", 1)
-        module = importlib.import_module(module_name)
-        cls: pydantic.BaseModel = getattr(module, function_name)
-        instance = cls(**modifier_kwargs)
+        if modifier not in self._loaded_modifiers:
+            module_name, function_name = modifier.rsplit(".", 1)
+            module = importlib.import_module(module_name)
+            cls: pydantic.BaseModel = getattr(module, function_name)
+            instance = cls(**modifier_kwargs)
+            self._loaded_modifiers[modifier] = instance
+        instance = self._loaded_modifiers[modifier]
+        kwargs = kwargs | modifier_kwargs
         atoms = instance.run(selected_ids, self.get_atoms(step=step).copy(), **kwargs)
         for key in list(self._atoms_cache.keys()):
             # we remove all steps after the current one

--- a/zndraw/shared.py
+++ b/zndraw/shared.py
@@ -119,8 +119,8 @@ class Config(BaseModel):
 
     def reset_scene_modifiers(self) -> None:
         """Reset the scene modifiers."""
-        for key in list(self._atoms_cache):
-            del self._atoms_cache[key]
+        for key in list(self._loaded_modifiers):
+            del self._loaded_modifiers[key]
         self._loaded_modifiers = {}
 
     def export_atoms(self):

--- a/zndraw/static/UI/UI.js
+++ b/zndraw/static/UI/UI.js
@@ -528,6 +528,12 @@ function resizeOffcanvas() {
   });
 }
 
+function sceneModifierResetBtnClick() {
+  document.getElementById("sceneModifierResetBtn").onclick = function () {
+    fetch("reset-scene-modifiers");
+  };
+}
+
 export function setUIEvents(config, world) {
   update_materials(config);
   updateFPS(config);
@@ -541,6 +547,7 @@ export function setUIEvents(config, world) {
   loadSceneModifier(config, world);
   loadSceneAnalysis(config, world);
   loadSceneBonds(config, world);
+  sceneModifierResetBtnClick();
 
   clickAddSceneModifier();
   resizeOffcanvas();

--- a/zndraw/templates/index.html
+++ b/zndraw/templates/index.html
@@ -177,7 +177,7 @@
         <input class="form-check-input" type="checkbox" value="" id="multiselect">
         <label for="multiselect" class="form-label">Select multiple particles</label>
       </div>
-      
+
       <div class="mb-3">
         <label for="addSceneModifier" class="form-label">Select scene modifier</label>
         <select class="form-select" aria-label="Default select example" id="addSceneModifier">

--- a/zndraw/templates/index.html
+++ b/zndraw/templates/index.html
@@ -190,6 +190,9 @@
         </div>
       </div>
       <div id="sceneModifierSettings"></div>
+      <div class="d-grid gap-2 col-6 mx-auto my-3">
+        <button type="button" class="btn btn-secondary" id="sceneModifierResetBtn">Reset Modifier</button>
+      </div>
     </div>
   </div>
 

--- a/zndraw/templates/index.html
+++ b/zndraw/templates/index.html
@@ -177,9 +177,7 @@
         <input class="form-check-input" type="checkbox" value="" id="multiselect">
         <label for="multiselect" class="form-label">Select multiple particles</label>
       </div>
-      <div class="d-grid gap-2 col-6 mx-auto mb-3">
-        <button type="button" class="btn btn-secondary" id="sceneModifierBtn">Modify</button>
-      </div>
+      
       <div class="mb-3">
         <label for="addSceneModifier" class="form-label">Select scene modifier</label>
         <select class="form-select" aria-label="Default select example" id="addSceneModifier">
@@ -190,9 +188,15 @@
         </div>
       </div>
       <div id="sceneModifierSettings"></div>
-      <div class="d-grid gap-2 col-6 mx-auto my-3">
-        <button type="button" class="btn btn-secondary" id="sceneModifierResetBtn">Reset Modifier</button>
+      <div class="row my-3">
+        <div class="col">
+          <button type="button" class="btn btn-danger w-100" id="sceneModifierResetBtn">Reset Modifier</button>
+        </div>
+        <div class="col">
+          <button type="button" class="btn btn-primary w-100" id="sceneModifierBtn">Modify</button>
+        </div>
       </div>
+
     </div>
   </div>
 


### PR DESCRIPTION
this allows for faster loading as the modifications don't need to be initialised each time
in addition, the kwargs now contains the current keys-values from the live settings of the modification

finally, changed the buffer size which was causing weird behaviour in terms of things being saved in atoms.info
and could cause endless streaming of the frames