### PR TITLE
No longer overwrites manual bonds

### DIFF
--- a/zndraw/zndraw.py
+++ b/zndraw/zndraw.py
@@ -155,10 +155,13 @@ class ZnDraw(collections.abc.MutableSequence):
     def _set_item(self, index, value):
         assert isinstance(value, ase.Atoms), "Must be an ASE Atoms object"
         assert isinstance(index, int), "Index must be an integer"
-        if self.bonds_calculator is not None:
-            value.connectivity = self.bonds_calculator.build_graph(value)
-        else:
-            value.connectivity = nx.Graph()
+        try:
+            bonds = value.connectivity
+        except AttributeError:
+            if self.bonds_calculator is not None:
+                value.connectivity = self.bonds_calculator.build_graph(value)
+            else:
+                value.connectivity = nx.Graph()
 
         self.socket.emit("atoms:upload", {index: atoms_to_json(value)})
 

--- a/zndraw/zndraw.py
+++ b/zndraw/zndraw.py
@@ -155,13 +155,13 @@ class ZnDraw(collections.abc.MutableSequence):
     def _set_item(self, index, value):
         assert isinstance(value, ase.Atoms), "Must be an ASE Atoms object"
         assert isinstance(index, int), "Index must be an integer"
-        try:
+        
+        if hasattr(value, connectivity):    
             pass
-        except AttributeError:
-            if self.bonds_calculator is not None:
-                value.connectivity = self.bonds_calculator.build_graph(value)
-            else:
-                value.connectivity = nx.Graph()
+        elif self.bonds_calculator is not None:
+            value.connectivity = self.bonds_calculator.build_graph(value)
+        else:
+            value.connectivity = nx.Graph()
 
         self.socket.emit("atoms:upload", {index: atoms_to_json(value)})
 

--- a/zndraw/zndraw.py
+++ b/zndraw/zndraw.py
@@ -156,7 +156,7 @@ class ZnDraw(collections.abc.MutableSequence):
         assert isinstance(value, ase.Atoms), "Must be an ASE Atoms object"
         assert isinstance(index, int), "Index must be an integer"
         
-        if hasattr(value, connectivity):    
+        if hasattr(value, "connectivity"):    
             pass
         elif self.bonds_calculator is not None:
             value.connectivity = self.bonds_calculator.build_graph(value)

--- a/zndraw/zndraw.py
+++ b/zndraw/zndraw.py
@@ -154,8 +154,7 @@ class ZnDraw(collections.abc.MutableSequence):
 
     def _set_item(self, index, value):
         assert isinstance(value, ase.Atoms), "Must be an ASE Atoms object"
-        assert isinstance(index, int), "Index must be an integer"
-        
+        assert isinstance(index, int), "Index must be an integer" 
         if hasattr(value, "connectivity"):    
             pass
         elif self.bonds_calculator is not None:

--- a/zndraw/zndraw.py
+++ b/zndraw/zndraw.py
@@ -154,8 +154,8 @@ class ZnDraw(collections.abc.MutableSequence):
 
     def _set_item(self, index, value):
         assert isinstance(value, ase.Atoms), "Must be an ASE Atoms object"
-        assert isinstance(index, int), "Index must be an integer" 
-        if hasattr(value, "connectivity"):    
+        assert isinstance(index, int), "Index must be an integer"
+        if hasattr(value, "connectivity"):
             pass
         elif self.bonds_calculator is not None:
             value.connectivity = self.bonds_calculator.build_graph(value)

--- a/zndraw/zndraw.py
+++ b/zndraw/zndraw.py
@@ -156,7 +156,7 @@ class ZnDraw(collections.abc.MutableSequence):
         assert isinstance(value, ase.Atoms), "Must be an ASE Atoms object"
         assert isinstance(index, int), "Index must be an integer"
         try:
-            bonds = value.connectivity
+            pass
         except AttributeError:
             if self.bonds_calculator is not None:
                 value.connectivity = self.bonds_calculator.build_graph(value)


### PR DESCRIPTION
No longer overwrites bonds that were added manually before the atoms object was sent to ZnDraw