### PR TITLE
add bookmarks support

### DIFF
--- a/zndraw/app.py
+++ b/zndraw/app.py
@@ -496,14 +496,17 @@ def modifier_register(data):
 
     emit("modifier:register", data, to=app.config["DEFAULT_PYCLIENT"])
 
+
 @io.on("bookmarks:get")
 def bookmarks_get(data: dict):
     if "sid" in data:
         return call("bookmarks:get", to=data["sid"])
     else:
         try:
-           # emit to all webclients in the group, if no sid is provided
-            return call("bookmarks:get", to=app.config["ROOM_HOSTS"][session["token"]][0])
+            # emit to all webclients in the group, if no sid is provided
+            return call(
+                "bookmarks:get", to=app.config["ROOM_HOSTS"][session["token"]][0]
+            )
         except KeyError:
             return "No host found."
 
@@ -515,7 +518,11 @@ def bookmarks_set(data: dict):
     else:
         try:
             # emit to all webclients in the group, if no sid is provided
-            emit("bookmarks:set", data["bookmarks"], include_self=False, to=session["token"])
+            emit(
+                "bookmarks:set",
+                data["bookmarks"],
+                include_self=False,
+                to=session["token"],
+            )
         except KeyError:
             return "No host found."
-    

--- a/zndraw/app.py
+++ b/zndraw/app.py
@@ -495,3 +495,27 @@ def modifier_register(data):
         print("Could not identify the modifier name.")
 
     emit("modifier:register", data, to=app.config["DEFAULT_PYCLIENT"])
+
+@io.on("bookmarks:get")
+def bookmarks_get(data: dict):
+    if "sid" in data:
+        return call("bookmarks:get", to=data["sid"])
+    else:
+        try:
+           # emit to all webclients in the group, if no sid is provided
+            return call("bookmarks:get", to=app.config["ROOM_HOSTS"][session["token"]][0])
+        except KeyError:
+            return "No host found."
+
+
+@io.on("bookmarks:set")
+def bookmarks_set(data: dict):
+    if "sid" in data:
+        emit("bookmarks:set", data["bookmarks"], include_self=False, to=data["sid"])
+    else:
+        try:
+            # emit to all webclients in the group, if no sid is provided
+            emit("bookmarks:set", data["bookmarks"], include_self=False, to=session["token"])
+        except KeyError:
+            return "No host found."
+    

--- a/zndraw/static/World/World.js
+++ b/zndraw/static/World/World.js
@@ -3,7 +3,6 @@ import { createLights } from "./components/lights.js";
 import { createScene } from "./components/scene.js";
 import { Bookmarks } from "../pycom/Bookmarks.js";
 
-
 import { createControls } from "./systems/controls.js";
 import { createRenderer, create2DRenderer } from "./systems/renderer.js";
 import { Resizer } from "./systems/Resizer.js";
@@ -182,7 +181,6 @@ class World {
     this.index_grp = new ParticleIndexGroup(this.particles, camera);
     const bookmarks = new Bookmarks(this, cache, socket);
 
-
     this.cell_grp = new CellGroup(cache);
 
     this.selection = new Selection(
@@ -226,7 +224,12 @@ class World {
     });
 
     loop.tick_updatables.push(controls, this.index_grp);
-    loop.step_updatables.push(this.particles, this.index_grp, this.cell_grp, bookmarks);
+    loop.step_updatables.push(
+      this.particles,
+      this.index_grp,
+      this.cell_grp,
+      bookmarks,
+    );
 
     const resizer = new Resizer(container, camera, renderer, renderer2d);
 

--- a/zndraw/static/World/World.js
+++ b/zndraw/static/World/World.js
@@ -1,6 +1,8 @@
 import { createCamera } from "./components/camera.js";
 import { createLights } from "./components/lights.js";
 import { createScene } from "./components/scene.js";
+import { Bookmarks } from "../pycom/Bookmarks.js";
+
 
 import { createControls } from "./systems/controls.js";
 import { createRenderer, create2DRenderer } from "./systems/renderer.js";
@@ -178,6 +180,8 @@ class World {
     this.particles = new ParticlesGroup(socket, cache);
     this.line3D = new Line3D(camera, renderer);
     this.index_grp = new ParticleIndexGroup(this.particles, camera);
+    const bookmarks = new Bookmarks(this, cache, socket);
+
 
     this.cell_grp = new CellGroup(cache);
 
@@ -222,7 +226,7 @@ class World {
     });
 
     loop.tick_updatables.push(controls, this.index_grp);
-    loop.step_updatables.push(this.particles, this.index_grp, this.cell_grp);
+    loop.step_updatables.push(this.particles, this.index_grp, this.cell_grp, bookmarks);
 
     const resizer = new Resizer(container, camera, renderer, renderer2d);
 

--- a/zndraw/static/World/World.js
+++ b/zndraw/static/World/World.js
@@ -27,12 +27,13 @@ let loop;
 let controls;
 
 class Player {
-  constructor(world, cache, socket) {
+  constructor(world, cache, socket, bookmarks) {
     this.world = world;
     this.playing = false;
     this.fps = 60;
     this.cache = cache;
     this.loop = false;
+    this.bookmarks = bookmarks;
 
     socket.on("scene:set", (index) => {
       this.world.setStep(index);
@@ -78,14 +79,22 @@ class Player {
         document.activeElement === document.body &&
         event.code === "ArrowRight"
       ) {
-        this.go_forward();
+        if (event.shiftKey) {
+          this.bookmarks.jumpNext();
+        } else {
+          this.go_forward();
+        }
       }
       // on arrow left go backward
       if (
         document.activeElement === document.body &&
         event.code === "ArrowLeft"
       ) {
-        this.go_backward();
+        if (event.shiftKey) {
+          this.bookmarks.jumpPrevious();
+        } else {
+          this.go_backward();
+        }
       }
       // on arrow up go forward 10 % of the length
       if (
@@ -171,15 +180,15 @@ class World {
 
     loop = new Loop(camera, scene, renderer, renderer2d);
     controls = createControls(camera, renderer.domElement);
+    const bookmarks = new Bookmarks(this, cache, socket);
 
-    this.player = new Player(this, cache, socket);
+    this.player = new Player(this, cache, socket, bookmarks);
 
     container.append(renderer.domElement);
 
     this.particles = new ParticlesGroup(socket, cache);
     this.line3D = new Line3D(camera, renderer);
     this.index_grp = new ParticleIndexGroup(this.particles, camera);
-    const bookmarks = new Bookmarks(this, cache, socket);
 
     this.cell_grp = new CellGroup(cache);
 

--- a/zndraw/static/main.js
+++ b/zndraw/static/main.js
@@ -1,5 +1,4 @@
 import { Cache } from "./pycom/Cache.js";
-import { Bookmarks } from "./pycom/Bookmarks.js";
 import { World } from "./World/World.js";
 import { setUIEvents } from "./UI/UI.js";
 import { initJSONEditor } from "./UI/json_editor.js";
@@ -29,7 +28,6 @@ function main() {
   const cache = new Cache(socket);
   const container = document.querySelector("#scene-container");
   const world = new World(container, cache, socket);
-  const bookmarks = new Bookmarks(world, cache, socket);
 
   setUIEvents(socket, cache, world);
   initJSONEditor(socket, cache, world);

--- a/zndraw/static/main.js
+++ b/zndraw/static/main.js
@@ -1,4 +1,5 @@
 import { Cache } from "./pycom/Cache.js";
+import { Bookmarks } from "./pycom/Bookmarks.js";
 import { World } from "./World/World.js";
 import { setUIEvents } from "./UI/UI.js";
 import { initJSONEditor } from "./UI/json_editor.js";
@@ -28,6 +29,7 @@ function main() {
   const cache = new Cache(socket);
   const container = document.querySelector("#scene-container");
   const world = new World(container, cache, socket);
+  const bookmarks = new Bookmarks(world, cache, socket);
 
   setUIEvents(socket, cache, world);
   initJSONEditor(socket, cache, world);

--- a/zndraw/static/pycom/Bookmarks.js
+++ b/zndraw/static/pycom/Bookmarks.js
@@ -66,6 +66,26 @@ class Bookmarks {
   step() {
     this.updateBookmarks();
   }
+
+  jumpNext() {
+    const step = this.world.getStep();
+    const bookmarks = Object.keys(this.bookmarks);
+    const next_bookmark = bookmarks.find((bookmark) => bookmark > step);
+    if (next_bookmark) {
+      this.world.setStep(next_bookmark);
+    }
+  }
+
+  jumpPrevious() {
+    const step = this.world.getStep();
+    const bookmarks = Object.keys(this.bookmarks);
+    const previous_bookmark = bookmarks
+      .reverse()
+      .find((bookmark) => bookmark < step);
+    if (previous_bookmark) {
+      this.world.setStep(previous_bookmark);
+    }
+  }
 }
 
 export { Bookmarks };

--- a/zndraw/static/pycom/Bookmarks.js
+++ b/zndraw/static/pycom/Bookmarks.js
@@ -8,12 +8,10 @@ class Bookmarks {
     this.socket.on(
       "bookmarks:get",
       function (callback) {
-        console.log("bookmarks:get");
         callback(this.bookmarks);
       }.bind(this),
     );
     this.socket.on("bookmarks:set", (bookmarks) => {
-      console.log("bookmarks:set");
       this.bookmarks = bookmarks;
       this.updateBookmarks();
     });
@@ -37,7 +35,13 @@ class Bookmarks {
     while (bookmark_envelope.firstChild) {
       bookmark_envelope.removeChild(bookmark_envelope.firstChild);
     }
-    console.log("update bookmarks");
+
+    // remove all bookmarks for frames larger than the cache length
+    for (const [index, name] of Object.entries(this.bookmarks)) {
+      if (index > this.cache.get_length()) {
+        delete this.bookmarks[index];
+      }
+    }
 
     for (const [index, name] of Object.entries(this.bookmarks)) {
       const button = document.createElement("button");
@@ -65,7 +69,6 @@ class Bookmarks {
 
       button.style.position = "absolute";
       button.style.bottom = "5px";
-      console.log(button.style.left);
       bookmark_envelope.appendChild(button);
     }
   }

--- a/zndraw/static/pycom/Bookmarks.js
+++ b/zndraw/static/pycom/Bookmarks.js
@@ -1,0 +1,65 @@
+
+class Bookmarks {
+    constructor(world, cache, socket) {
+        this.world = world;
+        this.cache = cache;
+        this.socket = socket;
+        this.bookmarks = { };
+
+        this.socket.on("bookmarks:get", function (callback) {
+            console.log("bookmarks:get");
+            callback(this.bookmarks);
+        }.bind(this));
+        this.socket.on("bookmarks:set", (bookmarks) => {
+            console.log("bookmarks:set");
+            this.bookmarks = bookmarks;
+            this.updateBookmarks();
+        });
+
+        // on keypress b set the bookmark
+        window.addEventListener("keypress", (event) => {
+            if (document.activeElement === document.body && event.key === "b") {
+                // get the current step
+                const step = this.world.getStep();
+                // // set the bookmark at the current step
+                this.bookmarks[step] = `Bookmark ${step}`;
+                // // update the bookmarks
+                this.updateBookmarks();
+            }
+        });
+    }
+
+    updateBookmarks() {
+        const bookmark_envelope = document.getElementById("bookmarks");
+        // remove all children
+        while (bookmark_envelope.firstChild) {
+            bookmark_envelope.removeChild(bookmark_envelope.firstChild);
+        }
+        console.log("update bookmarks");
+
+        for (const [index, name] of Object.entries(this.bookmarks)) {
+            const button = document.createElement("button");
+            button.type = "button";
+            button.className = "btn btn-link";
+            button.innerHTML = '<i class="fa-regular fa-bookmark"></i>';
+            // add data-bs-toggle="tooltip" data-bs-placement="top" title=name
+            button.setAttribute("data-bs-toggle", "tooltip");
+            button.setAttribute("data-bs-placement", "top");
+            button.setAttribute("title", name);
+            // set z-index to 100
+            button.style.zIndex = "100";
+            button.addEventListener("click", () => {
+                this.world.setStep(index);
+            });
+            // set the position of the button to be relative  index / this.cache.get_length()
+            button.style.left = `${(index / this.cache.get_length()) * 100}%`;
+            button.style.position = "absolute";
+            button.style.bottom = "5px";
+            console.log(button.style.left);
+            bookmark_envelope.appendChild(button);
+
+        }
+    }
+}
+
+export { Bookmarks };

--- a/zndraw/static/pycom/Bookmarks.js
+++ b/zndraw/static/pycom/Bookmarks.js
@@ -55,11 +55,16 @@ class Bookmarks {
       });
       // set the position of the button to be relative  index / this.cache.get_length()
       button.style.left = `${(index / this.cache.get_length()) * 100}%`;
+
       button.style.position = "absolute";
       button.style.bottom = "5px";
       console.log(button.style.left);
       bookmark_envelope.appendChild(button);
     }
+  }
+
+  step() {
+    this.updateBookmarks();
   }
 }
 

--- a/zndraw/static/pycom/Bookmarks.js
+++ b/zndraw/static/pycom/Bookmarks.js
@@ -50,8 +50,15 @@ class Bookmarks {
       button.setAttribute("title", name);
       // set z-index to 100
       button.style.zIndex = "100";
-      button.addEventListener("click", () => {
-        this.world.setStep(index);
+      button.addEventListener("click", (event) => {
+        // check if shift key is being pressed
+        if (event.shiftKey) {
+          // delete the bookmark
+          delete this.bookmarks[index];
+          this.updateBookmarks();
+        } else {
+          this.world.setStep(index);
+        }
       });
       // set the position of the button to be relative  index / this.cache.get_length()
       button.style.left = `${(index / this.cache.get_length()) * 100}%`;

--- a/zndraw/static/pycom/Bookmarks.js
+++ b/zndraw/static/pycom/Bookmarks.js
@@ -1,65 +1,66 @@
-
 class Bookmarks {
-    constructor(world, cache, socket) {
-        this.world = world;
-        this.cache = cache;
-        this.socket = socket;
-        this.bookmarks = { };
+  constructor(world, cache, socket) {
+    this.world = world;
+    this.cache = cache;
+    this.socket = socket;
+    this.bookmarks = {};
 
-        this.socket.on("bookmarks:get", function (callback) {
-            console.log("bookmarks:get");
-            callback(this.bookmarks);
-        }.bind(this));
-        this.socket.on("bookmarks:set", (bookmarks) => {
-            console.log("bookmarks:set");
-            this.bookmarks = bookmarks;
-            this.updateBookmarks();
-        });
+    this.socket.on(
+      "bookmarks:get",
+      function (callback) {
+        console.log("bookmarks:get");
+        callback(this.bookmarks);
+      }.bind(this),
+    );
+    this.socket.on("bookmarks:set", (bookmarks) => {
+      console.log("bookmarks:set");
+      this.bookmarks = bookmarks;
+      this.updateBookmarks();
+    });
 
-        // on keypress b set the bookmark
-        window.addEventListener("keypress", (event) => {
-            if (document.activeElement === document.body && event.key === "b") {
-                // get the current step
-                const step = this.world.getStep();
-                // // set the bookmark at the current step
-                this.bookmarks[step] = `Bookmark ${step}`;
-                // // update the bookmarks
-                this.updateBookmarks();
-            }
-        });
+    // on keypress b set the bookmark
+    window.addEventListener("keypress", (event) => {
+      if (document.activeElement === document.body && event.key === "b") {
+        // get the current step
+        const step = this.world.getStep();
+        // // set the bookmark at the current step
+        this.bookmarks[step] = `Bookmark ${step}`;
+        // // update the bookmarks
+        this.updateBookmarks();
+      }
+    });
+  }
+
+  updateBookmarks() {
+    const bookmark_envelope = document.getElementById("bookmarks");
+    // remove all children
+    while (bookmark_envelope.firstChild) {
+      bookmark_envelope.removeChild(bookmark_envelope.firstChild);
     }
+    console.log("update bookmarks");
 
-    updateBookmarks() {
-        const bookmark_envelope = document.getElementById("bookmarks");
-        // remove all children
-        while (bookmark_envelope.firstChild) {
-            bookmark_envelope.removeChild(bookmark_envelope.firstChild);
-        }
-        console.log("update bookmarks");
-
-        for (const [index, name] of Object.entries(this.bookmarks)) {
-            const button = document.createElement("button");
-            button.type = "button";
-            button.className = "btn btn-link";
-            button.innerHTML = '<i class="fa-regular fa-bookmark"></i>';
-            // add data-bs-toggle="tooltip" data-bs-placement="top" title=name
-            button.setAttribute("data-bs-toggle", "tooltip");
-            button.setAttribute("data-bs-placement", "top");
-            button.setAttribute("title", name);
-            // set z-index to 100
-            button.style.zIndex = "100";
-            button.addEventListener("click", () => {
-                this.world.setStep(index);
-            });
-            // set the position of the button to be relative  index / this.cache.get_length()
-            button.style.left = `${(index / this.cache.get_length()) * 100}%`;
-            button.style.position = "absolute";
-            button.style.bottom = "5px";
-            console.log(button.style.left);
-            bookmark_envelope.appendChild(button);
-
-        }
+    for (const [index, name] of Object.entries(this.bookmarks)) {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "btn btn-link";
+      button.innerHTML = '<i class="fa-regular fa-bookmark"></i>';
+      // add data-bs-toggle="tooltip" data-bs-placement="top" title=name
+      button.setAttribute("data-bs-toggle", "tooltip");
+      button.setAttribute("data-bs-placement", "top");
+      button.setAttribute("title", name);
+      // set z-index to 100
+      button.style.zIndex = "100";
+      button.addEventListener("click", () => {
+        this.world.setStep(index);
+      });
+      // set the position of the button to be relative  index / this.cache.get_length()
+      button.style.left = `${(index / this.cache.get_length()) * 100}%`;
+      button.style.position = "absolute";
+      button.style.bottom = "5px";
+      console.log(button.style.left);
+      bookmark_envelope.appendChild(button);
     }
+  }
 }
 
 export { Bookmarks };

--- a/zndraw/templates/index.jinja2
+++ b/zndraw/templates/index.jinja2
@@ -303,6 +303,8 @@
               <dd class="col-sm-9"><code>keypress B</code></dd>
               <dt class="col-sm-3">jump between bookmarks</dt>
               <dd class="col-sm-9"><code>shift + keypress &#9654;\&#9664; </code></dd>
+              <dt class="col-sm-3">remove bookmark</dt>
+              <dd class="col-sm-9"><code>shift + mouse click </code></dd>
             </dl>
           </div>
         </div>

--- a/zndraw/templates/index.jinja2
+++ b/zndraw/templates/index.jinja2
@@ -431,6 +431,11 @@
   <div id="info"></div>
   <input id="frame-slider" class="frame-slider" type="range" value="0" min="0" max="100" />
 
+  <!-- Progress Bar Bookmarks -->
+  <div id="bookmarks">
+  {# <button type="button" class="btn btn-link"><i class="fa-regular fa-bookmark"></i></button> #}
+  </div>
+
   <!-- Additional info bars -->
   <div class="alert alert-secondary" role="alert" id="alertBoxDrawing">
     <h4 class="alert-heading">Drawing Mode</h4>

--- a/zndraw/templates/index.jinja2
+++ b/zndraw/templates/index.jinja2
@@ -294,6 +294,10 @@
               <dd class="col-sm-9">
                 <code>keypress shift</code> + <code>mousewheel</code>
               </dd>
+              <dt class="col-sm-3">add bookmark at current step</dt>
+              <dd class="col-sm-9"><code>keypress B</code></dd>
+              <dt class="col-sm-3">jump between bookmarks</dt>
+              <dd class="col-sm-9"><code>shift + keypress &#9654;\&#9664; </code></dd>
             </dl>
           </div>
         </div>

--- a/zndraw/zndraw.py
+++ b/zndraw/zndraw.py
@@ -215,6 +215,20 @@ class ZnDrawBase:  # collections.abc.MutableSequence
         self.socket.emit(
             "scene:pause", {"sid": self._target_sid if self._target_sid else self.token}
         )
+    
+    @property
+    def bookmarks(self) -> dict:
+        if self._target_sid is not None:
+            return self.socket.call("bookmarks:get", {"sid": self._target_sid})
+        else:
+            return self.socket.call("bookmarks:get", {})
+    
+    @bookmarks.setter
+    def bookmarks(self, value: dict):
+        data = {"bookmarks": value}
+        if self._target_sid is not None:
+            data["sid"] = self._target_sid
+        self.socket.emit("bookmarks:set", data)
 
 
 @dataclasses.dataclass

--- a/zndraw/zndraw.py
+++ b/zndraw/zndraw.py
@@ -215,14 +215,14 @@ class ZnDrawBase:  # collections.abc.MutableSequence
         self.socket.emit(
             "scene:pause", {"sid": self._target_sid if self._target_sid else self.token}
         )
-    
+
     @property
     def bookmarks(self) -> dict:
         if self._target_sid is not None:
             return self.socket.call("bookmarks:get", {"sid": self._target_sid})
         else:
             return self.socket.call("bookmarks:get", {})
-    
+
     @bookmarks.setter
     def bookmarks(self, value: dict):
         data = {"bookmarks": value}


### PR DESCRIPTION
With this PR we introduce `bookmarks` that allow to jump to specific scenes.
Bookmarks can be set by pressing `b` or through Python
```py
vis = ZnDraw(url="http://127.0.0.1:1234/")

print(vis.bookmarks) # dict

vis.bookmarks = {25: "Hello"} # add a bookmark for step 25 with the text "Hello"
```
Because of the way `property` works, it is **not** possible to use `vis.bookmarks.update({33: "something"})`!

This feature is also available in the new modifiers, allowing modifications to indicate what happend at the specific point in time.
Modifiers should always use `vis.bookmarks = vis.bookmarks | { <new bookmarks> }`

![image](https://github.com/zincware/ZnDraw/assets/46721498/4ddb531e-0645-48f5-b704-2e0c5d7d30be)
