### PR TITLE
add modifiers for wrap / center / replicate

### DIFF
--- a/zndraw/data.py
+++ b/zndraw/data.py
@@ -68,7 +68,7 @@ def atoms_from_json(data: dict) -> ase.Atoms:
         positions=data["positions"],
     )
 
-    atoms.arrays["colors"] = data["colors"]
+    atoms.arrays["colors"] = np.array(data["colors"])
 
     if "calc" in data:
         atoms.calc = SinglePointCalculator(atoms)

--- a/zndraw/modify/__init__.py
+++ b/zndraw/modify/__init__.py
@@ -286,6 +286,8 @@ class Replicate(UpdateScene):
     y: int = Field(2, ge=1)
     z: int = Field(2, ge=1)
 
+    keep_box: bool = Field(False, description="Keep the original box size")
+
     def run(self, vis: "ZnDraw") -> None:
         vis.log("Downloading atoms...")
         atoms_list = list(vis)
@@ -295,6 +297,8 @@ class Replicate(UpdateScene):
 
         for idx, atoms in enumerate(atoms_list):
             atoms = atoms.repeat((self.x, self.y, self.z))
+            if self.keep_box:
+                atoms.cell = atoms_list[idx].cell
             vis[idx] = atoms
             vis.step = idx
 

--- a/zndraw/modify/__init__.py
+++ b/zndraw/modify/__init__.py
@@ -219,6 +219,7 @@ class AddLineParticles(UpdateScene):
 
 class Wrap(UpdateScene):
     """Wrap the atoms to the cell."""
+
     discriminator: t.Literal["Wrap"] = Field("Wrap")
     recompute_bonds: bool = True
 
@@ -236,11 +237,15 @@ class Wrap(UpdateScene):
             vis[idx] = atoms
             vis.step = idx
 
+
 class Center(UpdateScene):
     """Move the atoms, such that the selected atom is in the center of the cell."""
+
     discriminator: t.Literal["Center"] = Field("Center")
     recompute_bonds: bool = True
-    dynamic: bool = Field(False, description="Move the atoms to the center of the cell at each step")
+    dynamic: bool = Field(
+        False, description="Move the atoms to the center of the cell at each step"
+    )
     wrap: bool = Field(True, description="Wrap the atoms to the cell")
 
     def run(self, vis: "ZnDraw") -> None:
@@ -248,7 +253,6 @@ class Center(UpdateScene):
         if len(selection) != 1:
             vis.log("Please select exactly one atom to center on.")
             return
-        
 
         vis.log("Downloading atoms...")
         atoms_list = list(vis)
@@ -257,7 +261,7 @@ class Center(UpdateScene):
             center = atoms_list[vis.step][selection[0]].position
         else:
             center = None
-        
+
         vis.step = 0
 
         del vis[1:]
@@ -274,6 +278,7 @@ class Center(UpdateScene):
 
             vis[idx] = atoms
             vis.step = idx
+
 
 class Replicate(UpdateScene):
     discriminator: t.Literal["Replicate"] = Field("Replicate")
@@ -292,8 +297,6 @@ class Replicate(UpdateScene):
             atoms = atoms.repeat((self.x, self.y, self.z))
             vis[idx] = atoms
             vis.step = idx
-
-
 
 
 # class CustomModifier(UpdateScene):

--- a/zndraw/settings.py
+++ b/zndraw/settings.py
@@ -21,6 +21,9 @@ _MODIFY_FUNCTIONS = [
     "zndraw.modify.AddLineParticles",
     "zndraw.modify.Rotate",
     "zndraw.modify.ChangeType",
+    "zndraw.modify.Wrap",
+    "zndraw.modify.Center",
+    "zndraw.modify.Replicate",
     # "zndraw.modify.CustomModifier",
 ]
 


### PR DESCRIPTION
Add modifiers that allow to:
- replicate the entire trajectory along x/y/z axis.
- wrap the entire trajectory into the simulation box.
- center the selected particle in the middle of the box and wrap all particles around it.

All these modifiers will change the `ase.Atoms` / underlying trajectory, e.g. the replicas will not just be "virtual", they will be added to the atoms objects and e.g. energies and forces will no longer be available.

# TODO:
- [x] add keep original box option
