### PR TITLE
UUID for modifiers

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,7 @@ def setup(request):
 
 
 def run_server(port):
-    app = create_app(None, False, True, None)
+    app = create_app(None, False, True, None, None)
     socketio.run(
         app, port=port, debug=False, host="0.0.0.0"
     )  # NEVER EVER USE  DEBUG=TRUE HERE!!!

--- a/zndraw/app.py
+++ b/zndraw/app.py
@@ -7,7 +7,7 @@ socketio = SocketIO()
 
 
 def create_app(
-    use_token, upgrade_insecure_requests, compute_bonds, tutorial: str
+    use_token, upgrade_insecure_requests, compute_bonds, tutorial: str, auth_token: str
 ) -> Flask:
     """Create the Flask app."""
 
@@ -21,6 +21,7 @@ def create_app(
     app.config["pyclients"] = {}
     # dict of {token: dict}
     app.config["PER-TOKEN-DATA"] = {}
+    app.config["AUTH_TOKEN"] = auth_token
 
     if not use_token:  # TODO: handle this differently
         app.config["token"] = "notoken"

--- a/zndraw/app.py
+++ b/zndraw/app.py
@@ -18,7 +18,9 @@ def create_app(
     app.config["TUTORIAL"] = tutorial
     app.config["MODIFIER"] = {"default_schema": {}, "active": None}
     # dict of {uuid: sid} for each client
-    app.config["pyclients"] = {} 
+    app.config["pyclients"] = {}
+    # dict of {token: dict}
+    app.config["PER-TOKEN-DATA"] = {}
 
     if not use_token:  # TODO: handle this differently
         app.config["token"] = "notoken"

--- a/zndraw/app.py
+++ b/zndraw/app.py
@@ -17,6 +17,8 @@ def create_app(
     app.config["DEFAULT_PYCLIENT"] = None
     app.config["TUTORIAL"] = tutorial
     app.config["MODIFIER"] = {"default_schema": {}, "active": None}
+    # dict of {uuid: sid} for each client
+    app.config["pyclients"] = {} 
 
     if not use_token:  # TODO: handle this differently
         app.config["token"] = "notoken"

--- a/zndraw/cli.py
+++ b/zndraw/cli.py
@@ -68,6 +68,10 @@ def main(
         None,
         help="Show the tutorial from the URL inside an IFrame.",
     ),
+    auth_token: str = typer.Option(
+        None,
+        help="Token to authenticate pyclient requests to the ZnDraw server, e.g., for adding defaults to all webclients.",
+    ),
 ):
     """Start the ZnDraw server.
 
@@ -91,4 +95,5 @@ def main(
         remote=remote,
         rev=rev,
         tutorial=tutorial,
+        auth_token=auth_token,
     )

--- a/zndraw/server/events.py
+++ b/zndraw/server/events.py
@@ -394,8 +394,6 @@ def modifier_register(data):
                 msg = "Unauthenticated users cannot register default modifiers."
                 log.critical(msg)
                 emit("message:log", msg, to=request.sid)
-            log.critical(app.config["MODIFIER"])
-            log.critical(f"{name = }")
             app.config["MODIFIER"]["default_schema"][name] = data["modifiers"][0][
                 "schema"
             ]

--- a/zndraw/server/events.py
+++ b/zndraw/server/events.py
@@ -374,9 +374,7 @@ def modifier_register(data):
         name = data["modifiers"][0]["name"]
         if name in app.config["MODIFIER"]["default_schema"]:
             msg = f"Modifier {name} is already registered (default)."
-            log.critical(
-                msg
-            )
+            log.critical(msg)
             emit("message:log", msg, to=request.sid)
 
         if name in app.config["PER-TOKEN-DATA"][session["token"]]["modifier"]:

--- a/zndraw/server/events.py
+++ b/zndraw/server/events.py
@@ -391,9 +391,9 @@ def modifier_register(data):
 
         if data["modifiers"][0]["default"]:
             if not session["authenticated"]:
-                raise ValueError(
-                    "Unauthenticated users cannot register default modifiers."
-                )
+                msg = "Unauthenticated users cannot register default modifiers."
+                log.critical(msg)
+                emit("message:log", msg, to=request.sid)
             log.critical(app.config["MODIFIER"])
             log.critical(f"{name = }")
             app.config["MODIFIER"]["default_schema"][name] = data["modifiers"][0][

--- a/zndraw/server/events.py
+++ b/zndraw/server/events.py
@@ -54,6 +54,7 @@ def _get_uuid_for_sid(sid) -> str:
     inv_clients = {v: k for k, v in app.config["pyclients"].items()}
     return inv_clients[sid]
 
+
 def _get_queue_position(job_id) -> int:
     """Return the position of the job_id in the queue."""
     try:
@@ -211,7 +212,7 @@ def modifier_run(data):
     # emit entered the queue
     JOB_ID = uuid4()
     app.config["MODIFIER"]["queue"].append(JOB_ID)
-    
+
     while True:
         if app.config["MODIFIER"]["queue"][0] == JOB_ID:
             acquired = modifier_lock.acquire(blocking=False)

--- a/zndraw/server/events.py
+++ b/zndraw/server/events.py
@@ -200,9 +200,13 @@ def modifier_run(data):
 
     name = data["params"]["method"]["discriminator"]
 
+    # handle custom modifiers (not default)
     if name in app.config["PER-TOKEN-DATA"][session["token"]].get("modifier", {}):
         token = app.config["PER-TOKEN-DATA"][session["token"]]["modifier"][name]
         data["sid"] = app.config["pyclients"][token]
+    # handle custom modifiers (default)
+    elif name in app.config["MODIFIER"]:
+        data["sid"] = app.config["pyclients"][app.config["MODIFIER"][name]]
 
     # need to set the target of the modifier to the webclients room
     data["target"] = session["token"]
@@ -240,7 +244,6 @@ def atoms_download(data):
 
 @io.on("atoms:upload")
 def atoms_upload(data: dict):
-    print(f"atoms:upload {data.keys()}")
     to = _webclients_default(data)
     # remove token and sid from the data, because JavaScript does not expect it
     data.pop("token", None)
@@ -397,6 +400,7 @@ def modifier_register(data):
             app.config["MODIFIER"]["default_schema"][name] = data["modifiers"][0][
                 "schema"
             ]
+            app.config["MODIFIER"][name] = _tmp[request.sid]
     except KeyError:
         print("Could not identify the modifier name.")
         traceback.print_exc()

--- a/zndraw/server/events.py
+++ b/zndraw/server/events.py
@@ -368,7 +368,9 @@ def modifier_register(data):
         name = data["modifiers"][0]["name"]
         # get the key from the value request.sid by inverting the dict
         _tmp = {v: k for k, v in app.config["pyclients"].items()}
-        app.config["PER-TOKEN-DATA"][session["token"]]["modifier"][name] = _tmp[request.sid]
+        app.config["PER-TOKEN-DATA"][session["token"]]["modifier"][name] = _tmp[
+            request.sid
+        ]
         log.critical(f'{app.config["PER-TOKEN-DATA"] = }')
         log.critical(f'{app.config["pyclients"] = }')
 

--- a/zndraw/server/events.py
+++ b/zndraw/server/events.py
@@ -115,7 +115,9 @@ def join(data: dict):
     session["authenticated"] = auth_token == app.config["AUTH_TOKEN"]
     log.critical(f"{session['authenticated'] = }")
     if uuid in app.config["pyclients"]:
-        raise ValueError(f"UUID {uuid} is already registered in {app.config['pyclients']}.")
+        raise ValueError(
+            f"UUID {uuid} is already registered in {app.config['pyclients']}."
+        )
     app.config["pyclients"][uuid] = request.sid
     session["token"] = token
     join_room(f"pyclients_{token}")
@@ -391,10 +393,12 @@ def modifier_register(data):
         ]
         log.critical(f'{app.config["PER-TOKEN-DATA"] = }')
         log.critical(f'{app.config["pyclients"] = }')
-        
+
         if data["modifiers"][0]["default"]:
             if not session["authenticated"]:
-                raise ValueError("Unauthenticated users cannot register default modifiers.")
+                raise ValueError(
+                    "Unauthenticated users cannot register default modifiers."
+                )
             log.critical(app.config["MODIFIER"])
             log.critical(f"{name = }")
             app.config["MODIFIER"]["default_schema"][name] = data["modifiers"][0][

--- a/zndraw/server/events.py
+++ b/zndraw/server/events.py
@@ -41,6 +41,7 @@ def _pyclients_default(data: dict) -> str:
         return data["sid"]
     return app.config["DEFAULT_PYCLIENT"]
 
+
 def _get_uuid_for_sid(sid) -> str:
     """Given a sid, return the UUID that is associated with it.
     The SID is given by flask, the UUID is defined by zndraw
@@ -392,7 +393,9 @@ def modifier_register(data):
             log.critical(msg)
             emit("message:log", msg, to=request.sid)
         # get the key from the value request.sid by inverting the dict
-        app.config["PER-TOKEN-DATA"][session["token"]]["modifier"][name] = _get_uuid_for_sid(request.sid)
+        app.config["PER-TOKEN-DATA"][session["token"]]["modifier"][
+            name
+        ] = _get_uuid_for_sid(request.sid)
         log.critical(f'{app.config["PER-TOKEN-DATA"] = }')
         log.critical(f'{app.config["pyclients"] = }')
 

--- a/zndraw/server/events.py
+++ b/zndraw/server/events.py
@@ -373,7 +373,7 @@ def modifier_register(data):
         # we can only register one modifier at a time
         name = data["modifiers"][0]["name"]
         if name in app.config["MODIFIER"]["default_schema"]:
-            msg = f"Modifier {name} is already registered (default)."
+            msg = f"'{name}' is already registered as a default modifier and therefore reserved. Choose another name for your modifier!"
             log.critical(msg)
             emit("message:log", msg, to=request.sid)
 

--- a/zndraw/static/UI/json_editor.js
+++ b/zndraw/static/UI/json_editor.js
@@ -144,6 +144,7 @@ function modifier_editor(socket, cache, world) {
         alert("No response from server. Please try again.");
         document.getElementById("interaction-json-editor-submit").disabled =
           false;
+        socket.emit("modifier:run:failed");
       }
     }, 1000);
   });

--- a/zndraw/view.py
+++ b/zndraw/view.py
@@ -52,6 +52,7 @@ def view(
     remote: str = None,
     rev: str = None,
     tutorial: str = None,
+    auth_token: str = None,
 ):
     url = f"http://127.0.0.1:{port}"
 
@@ -60,13 +61,14 @@ def view(
         upgrade_insecure_requests=upgrade_insecure_requests,
         compute_bonds=compute_bonds,
         tutorial=tutorial,
+        auth_token=auth_token,
     )
 
     file_io = FileIO(filename, start, stop, step, remote, rev)
 
     proc = mp.Process(
         target=ZnDrawDefault,
-        kwargs={"url": url, "token": "default", "file_io": file_io},
+        kwargs={"url": url, "token": "default", "file_io": file_io, "auth_token": auth_token},
     )
     proc.start()
 

--- a/zndraw/view.py
+++ b/zndraw/view.py
@@ -68,7 +68,12 @@ def view(
 
     proc = mp.Process(
         target=ZnDrawDefault,
-        kwargs={"url": url, "token": "default", "file_io": file_io, "auth_token": auth_token},
+        kwargs={
+            "url": url,
+            "token": "default",
+            "file_io": file_io,
+            "auth_token": auth_token,
+        },
     )
     proc.start()
 

--- a/zndraw/zndraw.py
+++ b/zndraw/zndraw.py
@@ -5,8 +5,8 @@ import logging
 import pathlib
 import threading
 import typing as t
-from io import StringIO
 import uuid
+from io import StringIO
 
 import ase
 import ase.io
@@ -48,7 +48,7 @@ class ZnDrawBase:  # collections.abc.MutableSequence
     ----------
     display_new : bool
         Display new atoms in the webclient, when they are added.
-    
+
     token : str
         Identifies the session this instances is being connected to.
         Tokens can be shared.
@@ -67,7 +67,10 @@ class ZnDrawBase:  # collections.abc.MutableSequence
     def __post_init__(self):
         self._uuid = str(self._uuid)
         self.socket = socketio.Client()
-        self.socket.on("connect", lambda: self.socket.emit("join", {"token": self.token, "uuid": self._uuid}))
+        self.socket.on(
+            "connect",
+            lambda: self.socket.emit("join", {"token": self.token, "uuid": self._uuid}),
+        )
         self.socket.on("disconnect", lambda: self.socket.disconnect())
         self.socket.on("modifier:run", self._pre_modifier_run)
 
@@ -567,7 +570,7 @@ class ZnDraw(ZnDrawBase):
                         "name": cls.__name__,
                         "default": default,
                     }
-                ]
+                ],
             },
         )
         self._modifiers[cls.__name__] = {"cls": cls, "run_kwargs": run_kwargs}

--- a/zndraw/zndraw.py
+++ b/zndraw/zndraw.py
@@ -83,6 +83,11 @@ class ZnDrawBase:  # collections.abc.MutableSequence
                 self.socket.sleep(0.1)
         else:
             raise socketio.exceptions.ConnectionError
+    
+    def reconnect(self) -> None:
+        """Reconnect to the server."""
+        self.socket.disconnect()
+        self._connect()
 
     @contextlib.contextmanager
     def _set_sid(self, sid):

--- a/zndraw/zndraw.py
+++ b/zndraw/zndraw.py
@@ -29,18 +29,19 @@ from zndraw.utils import (
 
 log = logging.getLogger(__name__)
 
+
 @dataclasses.dataclass
 class Config:
     """Configuration for ZnDraw client.
-    
+
     Attributes
     ----------
     call_timeout : int
         Timeout for socket calls in seconds.
         Set to a smaller value to fail faster.
     """
-    call_timeout: int = 60
 
+    call_timeout: int = 60
 
 
 @dataclasses.dataclass
@@ -78,7 +79,7 @@ class ZnDrawBase:  # collections.abc.MutableSequence
     display_new: bool = True
     _uuid: uuid.UUID = dataclasses.field(default_factory=uuid.uuid4)
     auth_token: str = None
-    config : Config = dataclasses.field(default_factory=Config)
+    config: Config = dataclasses.field(default_factory=Config)
 
     _target_sid: str = None
 
@@ -129,7 +130,11 @@ class ZnDrawBase:  # collections.abc.MutableSequence
         self.token = old_token
 
     def __len__(self) -> int:
-        return int(self.socket.call("atoms:length", {"token": self.token}, timeout=self.config.call_timeout))
+        return int(
+            self.socket.call(
+                "atoms:length", {"token": self.token}, timeout=self.config.call_timeout
+            )
+        )
 
     def __setitem__(self, index, value):
         if not isinstance(value, ase.Atoms) and not isinstance(value, Frame):
@@ -211,7 +216,9 @@ class ZnDrawBase:  # collections.abc.MutableSequence
         index = [i if i >= 0 else length + i for i in index]
 
         data = {"indices": index, "token": self.token}
-        downloaded_data = self.socket.call("atoms:download", data, timeout=self.config.call_timeout)
+        downloaded_data = self.socket.call(
+            "atoms:download", data, timeout=self.config.call_timeout
+        )
 
         atoms_list = []
 
@@ -241,7 +248,9 @@ class ZnDrawBase:  # collections.abc.MutableSequence
 
     @property
     def points(self) -> np.ndarray:
-        data = self.socket.call("points:get", {"token": self.token}, timeout=self.config.call_timeout)
+        data = self.socket.call(
+            "points:get", {"token": self.token}, timeout=self.config.call_timeout
+        )
         return np.array([[val["x"], val["y"], val["z"]] for val in data])
 
     @points.setter
@@ -258,12 +267,17 @@ class ZnDrawBase:  # collections.abc.MutableSequence
 
     @property
     def segments(self) -> np.ndarray:
-        data = self.socket.call("scene:segments", {"token": self.token}, timeout=self.config.call_timeout)
+        data = self.socket.call(
+            "scene:segments", {"token": self.token}, timeout=self.config.call_timeout
+        )
         return np.array(data)
 
     @property
     def step(self) -> int:
-        step = int(self.socket.call("scene:step", {"token": self.token}), timeout=self.config.call_timeout)
+        step = int(
+            self.socket.call("scene:step", {"token": self.token}),
+            timeout=self.config.call_timeout,
+        )
         return step
 
     @step.setter
@@ -273,7 +287,9 @@ class ZnDrawBase:  # collections.abc.MutableSequence
 
     @property
     def selection(self) -> list[int]:
-        return self.socket.call("selection:get", {"token": self.token}, timeout=self.config.call_timeout)
+        return self.socket.call(
+            "selection:get", {"token": self.token}, timeout=self.config.call_timeout
+        )
 
     @selection.setter
     def selection(self, value: list[int]):
@@ -297,7 +313,9 @@ class ZnDrawBase:  # collections.abc.MutableSequence
 
     @property
     def bookmarks(self) -> dict:
-        return self.socket.call("bookmarks:get", {"token": self.token}, timeout=self.config.call_timeout)
+        return self.socket.call(
+            "bookmarks:get", {"token": self.token}, timeout=self.config.call_timeout
+        )
 
     @bookmarks.setter
     def bookmarks(self, value: dict):

--- a/zndraw/zndraw.py
+++ b/zndraw/zndraw.py
@@ -66,8 +66,9 @@ class ZnDrawBase:  # collections.abc.MutableSequence
     _target_sid: str = None
 
     def __post_init__(self):
+        self._uuid = str(self._uuid)
         self.socket = socketio.Client()
-        self.socket.on("connect", lambda: self.socket.emit("join", {"token": self.token, "uuid": str(self._uuid)}))
+        self.socket.on("connect", lambda: self.socket.emit("join", {"token": self.token, "uuid": self._uuid}))
         self.socket.on("disconnect", lambda: self.socket.disconnect())
         self.socket.on("modifier:run", self._pre_modifier_run)
 
@@ -560,7 +561,7 @@ class ZnDraw(ZnDrawBase):
         self.socket.emit(
             "modifier:register",
             {
-                "uuid": self.uuid,
+                "uuid": self._uuid,
                 "modifiers": [
                     {
                         "schema": cls.model_json_schema(),

--- a/zndraw/zndraw.py
+++ b/zndraw/zndraw.py
@@ -61,6 +61,7 @@ class ZnDrawBase:  # collections.abc.MutableSequence
     token: str = "notoken"
     display_new: bool = True
     _uuid: uuid.UUID = dataclasses.field(default_factory=uuid.uuid4)
+    auth_token: str = None
 
     _target_sid: str = None
 
@@ -69,7 +70,7 @@ class ZnDrawBase:  # collections.abc.MutableSequence
         self.socket = socketio.Client()
         self.socket.on(
             "connect",
-            lambda: self.socket.emit("join", {"token": self.token, "uuid": self._uuid}),
+            lambda: self.socket.emit("join", {"token": self.token, "uuid": self._uuid, "auth_token": self.auth_token}),
         )
         self.socket.on("disconnect", lambda: self.socket.disconnect())
         self.socket.on("modifier:run", self._pre_modifier_run)

--- a/zndraw/zndraw.py
+++ b/zndraw/zndraw.py
@@ -275,8 +275,11 @@ class ZnDrawBase:  # collections.abc.MutableSequence
     @property
     def step(self) -> int:
         step = int(
-            self.socket.call("scene:step", {"token": self.token}),
-            timeout=self.config.call_timeout,
+            self.socket.call(
+                "scene:step",
+                {"token": self.token},
+                timeout=self.config.call_timeout,
+            )
         )
         return step
 

--- a/zndraw/zndraw.py
+++ b/zndraw/zndraw.py
@@ -84,6 +84,7 @@ class ZnDrawBase:  # collections.abc.MutableSequence
         )
         self.socket.on("disconnect", lambda: self.socket.disconnect())
         self.socket.on("modifier:run", self._pre_modifier_run)
+        self.socket.on("message:log", lambda data: print(data))
 
     def _connect(self):
         for _ in range(100):

--- a/zndraw/zndraw.py
+++ b/zndraw/zndraw.py
@@ -70,7 +70,14 @@ class ZnDrawBase:  # collections.abc.MutableSequence
         self.socket = socketio.Client()
         self.socket.on(
             "connect",
-            lambda: self.socket.emit("join", {"token": self.token, "uuid": self._uuid, "auth_token": self.auth_token}),
+            lambda: self.socket.emit(
+                "join",
+                {
+                    "token": self.token,
+                    "uuid": self._uuid,
+                    "auth_token": self.auth_token,
+                },
+            ),
         )
         self.socket.on("disconnect", lambda: self.socket.disconnect())
         self.socket.on("modifier:run", self._pre_modifier_run)
@@ -84,7 +91,7 @@ class ZnDrawBase:  # collections.abc.MutableSequence
                 self.socket.sleep(0.1)
         else:
             raise socketio.exceptions.ConnectionError
-    
+
     def reconnect(self) -> None:
         """Reconnect to the server."""
         self.socket.disconnect()

--- a/zndraw/zndraw.py
+++ b/zndraw/zndraw.py
@@ -55,6 +55,9 @@ class ZnDrawBase:  # collections.abc.MutableSequence
     _uuid : uuid.UUID
         Unique identifier for this instance. Can be set for reconnecting
         but only ONE instance with the same uuid can be connected at the same time.
+    auth_token : str
+        Authentication token, used e.g. for registering modifiers to all users and
+        not just the current session.
     """
 
     url: str


### PR DESCRIPTION
Concept:
![image](https://github.com/zincware/ZnDraw/assets/46721498/c79d3e94-3f36-447b-8042-8068cf86cfed)

Changes
- name is still unique per token, but not per server instance
- custom modifiers are requested by their UUID
- each pyclient has a UUID and an SID (given by the flask connection). There is a mapping UUID<-->SID, where the UUID can be updated such that e.g. a reconnected instance replaces the original one, altough the SID has changed.

- [x] add `vis.reconnect()` which keeps the token but reconnects if something went wrong.
- [x] add `zndraw --global-modifier-auth-token <some-token>` and then `vis.register_modifier(MyModifier, default=True)` you have to also pass `vis.register_modifier(MyModifier, default=True, auth_token= <some-token>)`
- [x] handle all exceptions with proper log messages instead of errors



Use authentication via `zndraw --auth-token <any-token>` and `vis = ZnDraw(auth_token=<any-token>)`.

# Testing (use-token)
- [ ] register modifier without default and check if appears only at the correct token
- [ ] register modifier with default and check if everywhere
- [ ] reconnect without default and check if still works
- [ ] reconnect with default and check if works
- [ ] register modifier with the same name without default on two different tokens
- [ ] register modifier with the same name with default
- [ ] register modifier with default and set `--auth-token`
