### PR TITLE
Change size and color of progress bar

### DIFF
--- a/zndraw/templates/index.jinja2
+++ b/zndraw/templates/index.jinja2
@@ -482,8 +482,8 @@
 
   <div class="fixed-bottom" style="width: 100%;">
     <div class="progress" id="frameProgress" role="progressbar" aria-label="Basic example" aria-valuenow="50"
-      aria-valuemin="0" aria-valuemax="100" style="height: 8px">
-      <div class="progress-bar bg-secondary" id="frameProgressBar" style="width: 0%; transition: none;"></div>
+      aria-valuemin="0" aria-valuemax="100" style="height: 12px">
+      <div class="progress-bar bg-primary" id="frameProgressBar" style="width: 0%; transition: none;"></div>
     </div>
   </div>
 


### PR DESCRIPTION
The progress bar is now 50% wider and has a different color.
Motivation: The progress bar was too thin and hard to click.
The color was also too similar to the background color.
New color is the same as buttons on the top.