### PR TITLE
remove existing clients on reconnect

### DIFF
--- a/zndraw/app.py
+++ b/zndraw/app.py
@@ -226,9 +226,10 @@ class ZnDrawServer:
     @property
     def url_root(self):
         return f"http://127.0.0.1:{self.port}"
-    
+
     def _purge_old_modifier_clients(self, engine):
         from zndraw.db.schema import GlobalModifierClient, RoomModifierClient
+
         with Session(engine) as session:
             session.query(GlobalModifierClient).delete()
             session.query(RoomModifierClient).delete()

--- a/zndraw/app.py
+++ b/zndraw/app.py
@@ -9,6 +9,7 @@ from flask import Flask
 from flask_caching import Cache
 from flask_socketio import SocketIO
 from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
 
 from zndraw.db.schema import Base
 
@@ -216,6 +217,7 @@ class ZnDrawServer:
             pass  # only for sqlite config
         engine = create_engine(config.database.get_path())
         Base.metadata.create_all(engine)
+        self._purge_old_modifier_clients(engine)
 
         if browser:
             webbrowser.open(self.url_root)
@@ -224,3 +226,10 @@ class ZnDrawServer:
     @property
     def url_root(self):
         return f"http://127.0.0.1:{self.port}"
+    
+    def _purge_old_modifier_clients(self, engine):
+        from zndraw.db.schema import GlobalModifierClient, RoomModifierClient
+        with Session(engine) as session:
+            session.query(GlobalModifierClient).delete()
+            session.query(RoomModifierClient).delete()
+            session.commit()


### PR DESCRIPTION
@PythonFZ, I can't reproduce an error where a client is exists when I close the server and restart it. Can you send a snippet on how to reproduce that?