### PR TITLE
Clear-tools

### DIFF
--- a/zndraw/modify/__init__.py
+++ b/zndraw/modify/__init__.py
@@ -56,20 +56,6 @@ class Connect(UpdateScene):
         vis.selection = []
 
 
-class ClearScene(UpdateScene):
-    """Clear the scene, deleting all atoms and points."""
-
-    discriminator: t.Literal["ClearScene"] = Field("ClearScene")
-
-    def run(self, vis: "ZnDraw", **kwargs) -> None:
-        del vis[vis.step + 1 :]
-        vis.points = []
-        vis.append(ase.Atoms())
-        vis.selection = []
-        vis.step = len(vis) - 1
-        vis.camera = {"position": [0, 0, 20], "target": [0, 0, 0]}
-
-
 class Rotate(UpdateScene):
     """Rotate the selected atoms around a the line (2 points only)."""
 

--- a/zndraw/modify/private.py
+++ b/zndraw/modify/private.py
@@ -1,10 +1,13 @@
+import typing as t
+
 import ase
 from pydantic import Field
-import typing as t
+
 if t.TYPE_CHECKING:
     from zndraw.zndraw import ZnDraw
-    
+
 from . import UpdateScene
+
 
 class NewScene(UpdateScene):
     """Clear the scene, deleting all atoms and points."""
@@ -18,7 +21,8 @@ class NewScene(UpdateScene):
         vis.selection = []
         vis.step = len(vis) - 1
         vis.camera = {"position": [0, 0, 20], "target": [0, 0, 0]}
-        
+
+
 class ClearTools(UpdateScene):
     """Clear the tools, removing all guiding points and undoing any selection."""
 

--- a/zndraw/modify/private.py
+++ b/zndraw/modify/private.py
@@ -1,0 +1,29 @@
+import ase
+from pydantic import Field
+import typing as t
+if t.TYPE_CHECKING:
+    from zndraw.zndraw import ZnDraw
+    
+from . import UpdateScene
+
+class NewScene(UpdateScene):
+    """Clear the scene, deleting all atoms and points."""
+
+    discriminator: t.Literal["NewScene"] = Field("NewScene")
+
+    def run(self, vis: "ZnDraw", **kwargs) -> None:
+        del vis[vis.step + 1 :]
+        vis.points = []
+        vis.append(ase.Atoms())
+        vis.selection = []
+        vis.step = len(vis) - 1
+        vis.camera = {"position": [0, 0, 20], "target": [0, 0, 0]}
+        
+class ClearTools(UpdateScene):
+    """Clear the tools, removing all guiding points and undoing any selection."""
+
+    discriminator: t.Literal["ClearTools"] = Field("ClearTools")
+
+    def run(self, vis: "ZnDraw", **kwargs) -> None:
+        vis.points = []
+        vis.selection = []

--- a/zndraw/server/tasks.py
+++ b/zndraw/server/tasks.py
@@ -219,8 +219,6 @@ def modifier_schema(url: str, token: str):
 def read_file(url: str, target: str, token: str):
     from zndraw.zndraw_worker import ZnDrawWorker
 
-    config = GlobalConfig.load()
-
     vis = ZnDrawWorker(token=token, url=url)
 
     if len(vis) == 0:

--- a/zndraw/server/tasks.py
+++ b/zndraw/server/tasks.py
@@ -253,13 +253,7 @@ def read_file(url: str, target: str, token: str):
                 continue
             atoms_list.append(atoms)
 
-            if len(atoms_list) == config.read_batch_size:
-                vis.extend(atoms_list)
-                atoms_list = []
-
-        if len(atoms_list) > 0:
-            vis.extend(atoms_list)
-
+        vis.extend(atoms_list)
         vis.step = len(vis) - 1
     else:
         vis.upload(target)

--- a/zndraw/server/tasks.py
+++ b/zndraw/server/tasks.py
@@ -481,7 +481,8 @@ def _run_default_modifier(self, url: str, token: str, data: dict, queue_job_id: 
 
     vis = ZnDrawWorker(token=str(token), url=url)
     config = GlobalConfig.load()
-    cls = get_modify_class(config.get_modify_methods())
+    cls = get_modify_class(config.get_modify_methods(include_private=True))
+    log.critical(f"Running {data} on {cls}")
     modifier = cls(**data)
 
     msg = CeleryTaskData(

--- a/zndraw/server/tasks.py
+++ b/zndraw/server/tasks.py
@@ -476,7 +476,6 @@ def _run_default_modifier(self, url: str, token: str, data: dict, queue_job_id: 
     vis = ZnDrawWorker(token=str(token), url=url)
     config = GlobalConfig.load()
     cls = get_modify_class(config.get_modify_methods(include_private=True))
-    log.critical(f"Running {data} on {cls}")
     modifier = cls(**data)
 
     msg = CeleryTaskData(

--- a/zndraw/static/UI/UI.js
+++ b/zndraw/static/UI/UI.js
@@ -91,8 +91,11 @@ function setupDragDrop(socket) {
 function setupTrashClick(socket) {
   document.getElementById("trashBtn").addEventListener("click", () => {
     socket.emit("modifier:run", {
-      method: { discriminator: "ClearScene" },
+      method: { discriminator: "ClearTools" },
     });
+    setTimeout(function () {
+      document.getElementById("drawRemoveCanvas").click();
+    }, 1000);
     // TODO: should this be a modifier?
   });
 }

--- a/zndraw/static/misc/simgen.js
+++ b/zndraw/static/misc/simgen.js
@@ -39,7 +39,7 @@ const setupSiMGen = function (socket, world) {
 
   canvasButton.addEventListener("click", () => {
     socket.emit("modifier:run", {
-      method: { discriminator: "ClearScene" },
+      method: { discriminator: "NewScene" },
     });
     setTimeout(function () {
       document.getElementById("drawAddCanvas").click();

--- a/zndraw/templates/index.jinja2
+++ b/zndraw/templates/index.jinja2
@@ -76,7 +76,7 @@
           </li>
           <li class="nav-item mx-1">
             <button type="button" class="btn btn-outline-primary" id="trashBtn" data-bs-placement="bottom"
-              data-bs-toggle="tooltip" data-bs-title="Clear Scene"><i class="fa-solid fa-trash-can"></i></button>
+              data-bs-toggle="tooltip" data-bs-title="Remove all guiding points and canvases."><i class="fa-solid fa-hand-sparkles"></i></button>
           </li>
           {% if tutorial %}
           <li class="nav-item mx-1">


### PR DESCRIPTION
I've created a `private.py` in modifiers where we can place very specific modifiers that are only used by buttons. They can be accessed by the webclient directly but not by users in the interactions menu.

I've also made the `read_file` task use the proper batching which is already implemented in `vis.extend`.

However, I've left the `ZnDrawWorker.upload` to use the static batch size in the config. I like that when you refresh the page, the configs load one by one. Even if it would be more efficient to batch there as well, I think it would be a little confusing.

ToDos are changing placement of icons and maybe thinking of a better icon for the ClearTools button.