### PR TITLE
Use `znjson` instead of `znframe`

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -134,17 +134,18 @@ export default function App() {
   // if step changes
   useEffect(() => {
     socket.emit("room:frames:get", [step], (frames: Frames) => {
+      console.log(frames);
       // map positions: numbers[][] to THREE.Vector3[]
 
       for (const key in frames) {
         if (frames.hasOwnProperty(key)) {
-          const frame = frames[key];
+          const frame: Frame = frames[key]["value"];
           frame.positions = frame.positions.map(
             (position) =>
               new THREE.Vector3(position[0], position[1], position[2]),
           ) as THREE.Vector3[];
         }
-        setCurrentFrame(frames[step]);
+        setCurrentFrame(frames[step]["value"]);
         setNeedsUpdate(false); // rename this to something more descriptive
       }
     });

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -134,9 +134,6 @@ export default function App() {
   // if step changes
   useEffect(() => {
     socket.emit("room:frames:get", [step], (frames: Frames) => {
-      console.log(frames);
-      // map positions: numbers[][] to THREE.Vector3[]
-
       for (const key in frames) {
         if (frames.hasOwnProperty(key)) {
           const frame: Frame = frames[key]["value"];

--- a/app/src/components/particles.tsx
+++ b/app/src/components/particles.tsx
@@ -17,7 +17,7 @@ export interface Frame {
 ``;
 
 export interface Frames {
-  [key: number]: Frame;
+  [key: number]: { _type: string; value: Frame };
 }
 
 export const Player = ({

--- a/poetry.lock
+++ b/poetry.lock
@@ -284,7 +284,7 @@ files = [
 name = "attrs"
 version = "23.2.0"
 description = "Classes Without Boilerplate"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "attrs-23.2.0-py3-none-any.whl", hash = "sha256:99b87a485a5820b23b879f04c2305b44b951b502fd64be915879d77a7e8fc6f1"},
@@ -972,9 +972,9 @@ isort = ">=4.3.21,<6.0"
 jinja2 = ">=2.10.1,<4.0"
 packaging = "*"
 pydantic = [
-    {version = ">=1.10.0,<2.0.0 || >2.0.0,<2.0.1 || >2.0.1,<2.4.0 || >2.4.0,<3.0", extras = ["email"], markers = "python_version >= \"3.12\" and python_version < \"4.0\""},
-    {version = ">=1.10.0,<2.4.0 || >2.4.0,<3.0", extras = ["email"], markers = "python_version >= \"3.11\" and python_version < \"3.12\""},
     {version = ">=1.9.0,<2.4.0 || >2.4.0,<3.0", extras = ["email"], markers = "python_version >= \"3.10\" and python_version < \"3.11\""},
+    {version = ">=1.10.0,<2.4.0 || >2.4.0,<3.0", extras = ["email"], markers = "python_version >= \"3.11\" and python_version < \"3.12\""},
+    {version = ">=1.10.0,<2.0.0 || >2.0.0,<2.0.1 || >2.0.1,<2.4.0 || >2.4.0,<3.0", extras = ["email"], markers = "python_version >= \"3.12\" and python_version < \"4.0\""},
 ]
 pyyaml = ">=6.0.1"
 toml = {version = ">=0.10.0,<1.0.0", markers = "python_version < \"3.11\""}
@@ -3021,9 +3021,9 @@ files = [
 
 [package.dependencies]
 numpy = [
-    {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
-    {version = ">=1.23.2", markers = "python_version == \"3.11\""},
     {version = ">=1.22.4", markers = "python_version < \"3.11\""},
+    {version = ">=1.23.2", markers = "python_version == \"3.11\""},
+    {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
 ]
 python-dateutil = ">=2.8.2"
 pytz = ">=2020.1"
@@ -4791,32 +4791,14 @@ networkx = ">=3.0,<4.0"
 dask = ["bokeh (>=2.4.2,<3.0.0)", "dask (>=2022.12.1,<2023.0.0)", "dask-jobqueue (>=0.8.1,<0.9.0)", "distributed (>=2022.12.1,<2023.0.0)"]
 
 [[package]]
-name = "znframe"
-version = "0.1.5"
-description = "ZnFrame - ASE-like Interface based on dataclasses"
-optional = false
-python-versions = ">=3.9,<4.0"
-files = [
-    {file = "znframe-0.1.5-py3-none-any.whl", hash = "sha256:3645ee836b19f3d957686ba58f2fd4c142afef44df33764856848579e3af61f4"},
-    {file = "znframe-0.1.5.tar.gz", hash = "sha256:b5424e196af4df7fc8662c8ce6be5950a1307b763d4159bad69a0559448f6acf"},
-]
-
-[package.dependencies]
-ase = ">=3.22.1,<4.0.0"
-attrs = ">=23.1.0,<24.0.0"
-networkx = ">=3.2.1,<4.0.0"
-numpy = ">=1.26.2,<2.0.0"
-pydantic = ">=2.5.3,<3.0.0"
-
-[[package]]
 name = "znh5md"
-version = "0.2.0"
+version = "0.2.1"
 description = "High Performance Interface for H5MD Trajectories"
 optional = true
 python-versions = "<4.0,>=3.9"
 files = [
-    {file = "znh5md-0.2.0-py3-none-any.whl", hash = "sha256:563e5c9b6a1e29864d31c4731416eb4b79f7acfee23cbe8cc53730b247d1125b"},
-    {file = "znh5md-0.2.0.tar.gz", hash = "sha256:da60ca2e53f2d74cdc3a5954dbadae912973e4a29456329d2e6406f8d5e794bf"},
+    {file = "znh5md-0.2.1-py3-none-any.whl", hash = "sha256:73a4393544ed791d6aaa3850a30e14dd4f04e820c3cf5ea5f0aa74eab1be52d0"},
+    {file = "znh5md-0.2.1.tar.gz", hash = "sha256:aa10de0219f0abc0ab685c1e3d91b556ea9e03cca8e08c8d491e50dcd511cb0b"},
 ]
 
 [package.dependencies]
@@ -4903,4 +4885,4 @@ rdkit = ["rdkit2ase"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "28904682037b0f015c31ee09e1451c0db226f8a83e92dfe0a028323deba93ff1"
+content-hash = "76d89fb129c3dfe3da2cc64d4f88c05e1c1722008287e4dafa40207f16aa06f6"

--- a/poetry.lock
+++ b/poetry.lock
@@ -972,9 +972,9 @@ isort = ">=4.3.21,<6.0"
 jinja2 = ">=2.10.1,<4.0"
 packaging = "*"
 pydantic = [
-    {version = ">=1.9.0,<2.4.0 || >2.4.0,<3.0", extras = ["email"], markers = "python_version >= \"3.10\" and python_version < \"3.11\""},
-    {version = ">=1.10.0,<2.4.0 || >2.4.0,<3.0", extras = ["email"], markers = "python_version >= \"3.11\" and python_version < \"3.12\""},
     {version = ">=1.10.0,<2.0.0 || >2.0.0,<2.0.1 || >2.0.1,<2.4.0 || >2.4.0,<3.0", extras = ["email"], markers = "python_version >= \"3.12\" and python_version < \"4.0\""},
+    {version = ">=1.10.0,<2.4.0 || >2.4.0,<3.0", extras = ["email"], markers = "python_version >= \"3.11\" and python_version < \"3.12\""},
+    {version = ">=1.9.0,<2.4.0 || >2.4.0,<3.0", extras = ["email"], markers = "python_version >= \"3.10\" and python_version < \"3.11\""},
 ]
 pyyaml = ">=6.0.1"
 toml = {version = ">=0.10.0,<1.0.0", markers = "python_version < \"3.11\""}
@@ -3021,9 +3021,9 @@ files = [
 
 [package.dependencies]
 numpy = [
-    {version = ">=1.22.4", markers = "python_version < \"3.11\""},
-    {version = ">=1.23.2", markers = "python_version == \"3.11\""},
     {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
+    {version = ">=1.23.2", markers = "python_version == \"3.11\""},
+    {version = ">=1.22.4", markers = "python_version < \"3.11\""},
 ]
 python-dateutil = ">=2.8.2"
 pytz = ">=2020.1"
@@ -4903,4 +4903,4 @@ rdkit = ["rdkit2ase"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "018f62b93cd7caba2762e1242d2ac48f03f403cd17bbdac6279f2d151ec4ccca"
+content-hash = "28904682037b0f015c31ee09e1451c0db226f8a83e92dfe0a028323deba93ff1"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1110,13 +1110,13 @@ files = [
 
 [[package]]
 name = "dpath"
-version = "2.1.6"
+version = "2.2.0"
 description = "Filesystem-like pathing and searching for dictionaries"
 optional = true
 python-versions = ">=3.7"
 files = [
-    {file = "dpath-2.1.6-py3-none-any.whl", hash = "sha256:31407395b177ab63ef72e2f6ae268c15e938f2990a8ecf6510f5686c02b6db73"},
-    {file = "dpath-2.1.6.tar.gz", hash = "sha256:f1e07c72e8605c6a9e80b64bc8f42714de08a789c7de417e49c3f87a19692e47"},
+    {file = "dpath-2.2.0-py3-none-any.whl", hash = "sha256:b330a375ded0a0d2ed404440f6c6a715deae5313af40bbb01c8a41d891900576"},
+    {file = "dpath-2.2.0.tar.gz", hash = "sha256:34f7e630dc55ea3f219e555726f5da4b4b25f2200319c8e6902c394258dd6a3e"},
 ]
 
 [[package]]
@@ -1470,18 +1470,18 @@ files = [
 
 [[package]]
 name = "filelock"
-version = "3.14.0"
+version = "3.15.1"
 description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "filelock-3.14.0-py3-none-any.whl", hash = "sha256:43339835842f110ca7ae60f1e1c160714c5a6afd15a2873419ab185334975c0f"},
-    {file = "filelock-3.14.0.tar.gz", hash = "sha256:6ea72da3be9b8c82afd3edcf99f2fffbb5076335a5ae4d03248bb5b6c3eae78a"},
+    {file = "filelock-3.15.1-py3-none-any.whl", hash = "sha256:71b3102950e91dfc1bb4209b64be4dc8854f40e5f534428d8684f953ac847fac"},
+    {file = "filelock-3.15.1.tar.gz", hash = "sha256:58a2549afdf9e02e10720eaa4d4470f56386d7a6f72edd7d0596337af8ed7ad8"},
 ]
 
 [package.extras]
 docs = ["furo (>=2023.9.10)", "sphinx (>=7.2.6)", "sphinx-autodoc-typehints (>=1.25.2)"]
-testing = ["covdefaults (>=2.3)", "coverage (>=7.3.2)", "diff-cover (>=8.0.1)", "pytest (>=7.4.3)", "pytest-cov (>=4.1)", "pytest-mock (>=3.12)", "pytest-timeout (>=2.2)"]
+testing = ["covdefaults (>=2.3)", "coverage (>=7.3.2)", "diff-cover (>=8.0.1)", "pytest (>=7.4.3)", "pytest-asyncio (>=0.21)", "pytest-cov (>=4.1)", "pytest-mock (>=3.12)", "pytest-timeout (>=2.2)"]
 typing = ["typing-extensions (>=4.8)"]
 
 [[package]]
@@ -2917,57 +2917,57 @@ PyYAML = ">=5.1.0"
 
 [[package]]
 name = "orjson"
-version = "3.10.4"
+version = "3.10.5"
 description = "Fast, correct Python JSON library supporting dataclasses, datetimes, and numpy"
 optional = true
 python-versions = ">=3.8"
 files = [
-    {file = "orjson-3.10.4-cp310-cp310-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:afca963f19ca60c7aedadea9979f769139127288dd58ccf3f7c5e8e6dc62cabf"},
-    {file = "orjson-3.10.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42b112eff36ba7ccc7a9d6b87e17b9d6bde4312d05e3ddf66bf5662481dee846"},
-    {file = "orjson-3.10.4-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:02b192eaba048b1039eca9a0cef67863bd5623042f5c441889a9957121d97e14"},
-    {file = "orjson-3.10.4-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:827c3d0e4fc44242c82bfdb1a773235b8c0575afee99a9fa9a8ce920c14e440f"},
-    {file = "orjson-3.10.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca8ec09724f10ec209244caeb1f9f428b6bb03f2eda9ed5e2c4dd7f2b7fabd44"},
-    {file = "orjson-3.10.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:8eaa5d531a8fde11993cbcb27e9acf7d9c457ba301adccb7fa3a021bfecab46c"},
-    {file = "orjson-3.10.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e112aa7fc4ea67367ec5e86c39a6bb6c5719eddc8f999087b1759e765ddaf2d4"},
-    {file = "orjson-3.10.4-cp310-none-win32.whl", hash = "sha256:1538844fb88446c42da3889f8c4ecce95a630b5a5ba18ecdfe5aea596f4dff21"},
-    {file = "orjson-3.10.4-cp310-none-win_amd64.whl", hash = "sha256:de02811903a2e434127fba5389c3cc90f689542339a6e52e691ab7f693407b5a"},
-    {file = "orjson-3.10.4-cp311-cp311-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:358afaec75de7237dfea08e6b1b25d226e33a1e3b6dc154fc99eb697f24a1ffa"},
-    {file = "orjson-3.10.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bb4e292c3198ab3d93e5f877301d2746be4ca0ba2d9c513da5e10eb90e19ff52"},
-    {file = "orjson-3.10.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5c39e57cf6323a39238490092985d5d198a7da4a3be013cc891a33fef13a536e"},
-    {file = "orjson-3.10.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f86df433fc01361ff9270ad27455ce1ad43cd05e46de7152ca6adb405a16b2f6"},
-    {file = "orjson-3.10.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c9966276a2c97e93e6cbe8286537f88b2a071827514f0d9d47a0aefa77db458"},
-    {file = "orjson-3.10.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c499a14155a1f5a1e16e0cd31f6cf6f93965ac60a0822bc8340e7e2d3dac1108"},
-    {file = "orjson-3.10.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3087023ce904a327c29487eb7e1f2c060070e8dbb9a3991b8e7952a9c6e62f38"},
-    {file = "orjson-3.10.4-cp311-none-win32.whl", hash = "sha256:f965893244fe348b59e5ce560693e6dd03368d577ce26849b5d261ce31c70101"},
-    {file = "orjson-3.10.4-cp311-none-win_amd64.whl", hash = "sha256:c212f06fad6aa6ce85d5665e91a83b866579f29441a47d3865c57329c0857357"},
-    {file = "orjson-3.10.4-cp312-cp312-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:d0965a8b0131959833ca8a65af60285995d57ced0de2fd8f16fc03235975d238"},
-    {file = "orjson-3.10.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:27b64695d9f2aef3ae15a0522e370ec95c946aaea7f2c97a1582a62b3bdd9169"},
-    {file = "orjson-3.10.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:867d882ddee6a20be4c8b03ae3d2b0333894d53ad632d32bd9b8123649577171"},
-    {file = "orjson-3.10.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a0667458f8a8ceb6dee5c08fec0b46195f92c474cbbec71dca2a6b7fd5b67b8d"},
-    {file = "orjson-3.10.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a3eac9befc4eaec1d1ff3bba6210576be4945332dde194525601c5ddb5c060d3"},
-    {file = "orjson-3.10.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4343245443552eae240a33047a6d1bcac7a754ad4b1c57318173c54d7efb9aea"},
-    {file = "orjson-3.10.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:30153e269eea43e98918d4d462a36a7065031d9246407dfff2579a4e457515c1"},
-    {file = "orjson-3.10.4-cp312-none-win32.whl", hash = "sha256:1a7d092ee043abf3db19c2183115e80676495c9911843fdb3ebd48ca7b73079e"},
-    {file = "orjson-3.10.4-cp312-none-win_amd64.whl", hash = "sha256:07a2adbeb8b9efe6d68fc557685954a1f19d9e33f5cc018ae1a89e96647c1b65"},
-    {file = "orjson-3.10.4-cp38-cp38-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:f5a746f3d908bce1a1e347b9ca89864047533bdfab5a450066a0315f6566527b"},
-    {file = "orjson-3.10.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:465b4a8a3e459f8d304c19071b4badaa9b267c59207a005a7dd9dfe13d3a423f"},
-    {file = "orjson-3.10.4-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:35858d260728c434a3d91b60685ab32418318567e8902039837e1c2af2719e0b"},
-    {file = "orjson-3.10.4-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8a5ba090d40c4460312dd69c232b38c2ff67a823185cfe667e841c9dd5c06841"},
-    {file = "orjson-3.10.4-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5dde86755d064664e62e3612a166c28298aa8dfd35a991553faa58855ae739cc"},
-    {file = "orjson-3.10.4-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:020a9e9001cfec85c156ef3b185ff758b62ef986cefdb8384c4579facd5ce126"},
-    {file = "orjson-3.10.4-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:3bf8e6e3388a2e83a86466c912387e0f0a765494c65caa7e865f99969b76ba0d"},
-    {file = "orjson-3.10.4-cp38-none-win32.whl", hash = "sha256:c5a1cca6a4a3129db3da68a25dc0a459a62ae58e284e363b35ab304202d9ba9e"},
-    {file = "orjson-3.10.4-cp38-none-win_amd64.whl", hash = "sha256:ecd97d98d7bee3e3d51d0b51c92c457f05db4993329eea7c69764f9820e27eb3"},
-    {file = "orjson-3.10.4-cp39-cp39-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:71362daa330a2fc85553a1469185ac448547392a8f83d34e67779f8df3a52743"},
-    {file = "orjson-3.10.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d24b59d1fecb0fd080c177306118a143f7322335309640c55ed9580d2044e363"},
-    {file = "orjson-3.10.4-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e906670aea5a605b083ebb58d575c35e88cf880fa372f7cedaac3d51e98ff164"},
-    {file = "orjson-3.10.4-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7ce32ed4bc4d632268e4978e595fe5ea07e026b751482b4a0feec48f66a90abc"},
-    {file = "orjson-3.10.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1dcd34286246e0c5edd0e230d1da2daab2c1b465fcb6bac85b8d44057229d40a"},
-    {file = "orjson-3.10.4-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:c45d4b8c403e50beedb1d006a8916d9910ed56bceaf2035dc253618b44d0a161"},
-    {file = "orjson-3.10.4-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:aaed3253041b5002a4f5bfdf6f7b5cce657d974472b0699a469d439beba40381"},
-    {file = "orjson-3.10.4-cp39-none-win32.whl", hash = "sha256:9a4f41b7dbf7896f8dbf559b9b43dcd99e31e0d49ac1b59d74f52ce51ab10eb9"},
-    {file = "orjson-3.10.4-cp39-none-win_amd64.whl", hash = "sha256:6c4eb7d867ed91cb61e6514cb4f457aa01d7b0fd663089df60a69f3d38b69d4c"},
-    {file = "orjson-3.10.4.tar.gz", hash = "sha256:c912ed25b787c73fe994a5decd81c3f3b256599b8a87d410d799d5d52013af2a"},
+    {file = "orjson-3.10.5-cp310-cp310-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:545d493c1f560d5ccfc134803ceb8955a14c3fcb47bbb4b2fee0232646d0b932"},
+    {file = "orjson-3.10.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f4324929c2dd917598212bfd554757feca3e5e0fa60da08be11b4aa8b90013c1"},
+    {file = "orjson-3.10.5-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8c13ca5e2ddded0ce6a927ea5a9f27cae77eee4c75547b4297252cb20c4d30e6"},
+    {file = "orjson-3.10.5-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b6c8e30adfa52c025f042a87f450a6b9ea29649d828e0fec4858ed5e6caecf63"},
+    {file = "orjson-3.10.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:338fd4f071b242f26e9ca802f443edc588fa4ab60bfa81f38beaedf42eda226c"},
+    {file = "orjson-3.10.5-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:6970ed7a3126cfed873c5d21ece1cd5d6f83ca6c9afb71bbae21a0b034588d96"},
+    {file = "orjson-3.10.5-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:235dadefb793ad12f7fa11e98a480db1f7c6469ff9e3da5e73c7809c700d746b"},
+    {file = "orjson-3.10.5-cp310-none-win32.whl", hash = "sha256:be79e2393679eda6a590638abda16d167754393f5d0850dcbca2d0c3735cebe2"},
+    {file = "orjson-3.10.5-cp310-none-win_amd64.whl", hash = "sha256:c4a65310ccb5c9910c47b078ba78e2787cb3878cdded1702ac3d0da71ddc5228"},
+    {file = "orjson-3.10.5-cp311-cp311-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:cdf7365063e80899ae3a697def1277c17a7df7ccfc979990a403dfe77bb54d40"},
+    {file = "orjson-3.10.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b68742c469745d0e6ca5724506858f75e2f1e5b59a4315861f9e2b1df77775a"},
+    {file = "orjson-3.10.5-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7d10cc1b594951522e35a3463da19e899abe6ca95f3c84c69e9e901e0bd93d38"},
+    {file = "orjson-3.10.5-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dcbe82b35d1ac43b0d84072408330fd3295c2896973112d495e7234f7e3da2e1"},
+    {file = "orjson-3.10.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:10c0eb7e0c75e1e486c7563fe231b40fdd658a035ae125c6ba651ca3b07936f5"},
+    {file = "orjson-3.10.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:53ed1c879b10de56f35daf06dbc4a0d9a5db98f6ee853c2dbd3ee9d13e6f302f"},
+    {file = "orjson-3.10.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:099e81a5975237fda3100f918839af95f42f981447ba8f47adb7b6a3cdb078fa"},
+    {file = "orjson-3.10.5-cp311-none-win32.whl", hash = "sha256:1146bf85ea37ac421594107195db8bc77104f74bc83e8ee21a2e58596bfb2f04"},
+    {file = "orjson-3.10.5-cp311-none-win_amd64.whl", hash = "sha256:36a10f43c5f3a55c2f680efe07aa93ef4a342d2960dd2b1b7ea2dd764fe4a37c"},
+    {file = "orjson-3.10.5-cp312-cp312-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:68f85ecae7af14a585a563ac741b0547a3f291de81cd1e20903e79f25170458f"},
+    {file = "orjson-3.10.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:28afa96f496474ce60d3340fe8d9a263aa93ea01201cd2bad844c45cd21f5268"},
+    {file = "orjson-3.10.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9cd684927af3e11b6e754df80b9ffafd9fb6adcaa9d3e8fdd5891be5a5cad51e"},
+    {file = "orjson-3.10.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3d21b9983da032505f7050795e98b5d9eee0df903258951566ecc358f6696969"},
+    {file = "orjson-3.10.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1ad1de7fef79736dde8c3554e75361ec351158a906d747bd901a52a5c9c8d24b"},
+    {file = "orjson-3.10.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2d97531cdfe9bdd76d492e69800afd97e5930cb0da6a825646667b2c6c6c0211"},
+    {file = "orjson-3.10.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d69858c32f09c3e1ce44b617b3ebba1aba030e777000ebdf72b0d8e365d0b2b3"},
+    {file = "orjson-3.10.5-cp312-none-win32.whl", hash = "sha256:64c9cc089f127e5875901ac05e5c25aa13cfa5dbbbd9602bda51e5c611d6e3e2"},
+    {file = "orjson-3.10.5-cp312-none-win_amd64.whl", hash = "sha256:b2efbd67feff8c1f7728937c0d7f6ca8c25ec81373dc8db4ef394c1d93d13dc5"},
+    {file = "orjson-3.10.5-cp38-cp38-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:03b565c3b93f5d6e001db48b747d31ea3819b89abf041ee10ac6988886d18e01"},
+    {file = "orjson-3.10.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:584c902ec19ab7928fd5add1783c909094cc53f31ac7acfada817b0847975f26"},
+    {file = "orjson-3.10.5-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5a35455cc0b0b3a1eaf67224035f5388591ec72b9b6136d66b49a553ce9eb1e6"},
+    {file = "orjson-3.10.5-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1670fe88b116c2745a3a30b0f099b699a02bb3482c2591514baf5433819e4f4d"},
+    {file = "orjson-3.10.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:185c394ef45b18b9a7d8e8f333606e2e8194a50c6e3c664215aae8cf42c5385e"},
+    {file = "orjson-3.10.5-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:ca0b3a94ac8d3886c9581b9f9de3ce858263865fdaa383fbc31c310b9eac07c9"},
+    {file = "orjson-3.10.5-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:dfc91d4720d48e2a709e9c368d5125b4b5899dced34b5400c3837dadc7d6271b"},
+    {file = "orjson-3.10.5-cp38-none-win32.whl", hash = "sha256:c05f16701ab2a4ca146d0bca950af254cb7c02f3c01fca8efbbad82d23b3d9d4"},
+    {file = "orjson-3.10.5-cp38-none-win_amd64.whl", hash = "sha256:8a11d459338f96a9aa7f232ba95679fc0c7cedbd1b990d736467894210205c09"},
+    {file = "orjson-3.10.5-cp39-cp39-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:85c89131d7b3218db1b24c4abecea92fd6c7f9fab87441cfc342d3acc725d807"},
+    {file = "orjson-3.10.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fb66215277a230c456f9038d5e2d84778141643207f85336ef8d2a9da26bd7ca"},
+    {file = "orjson-3.10.5-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:51bbcdea96cdefa4a9b4461e690c75ad4e33796530d182bdd5c38980202c134a"},
+    {file = "orjson-3.10.5-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dbead71dbe65f959b7bd8cf91e0e11d5338033eba34c114f69078d59827ee139"},
+    {file = "orjson-3.10.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5df58d206e78c40da118a8c14fc189207fffdcb1f21b3b4c9c0c18e839b5a214"},
+    {file = "orjson-3.10.5-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:c4057c3b511bb8aef605616bd3f1f002a697c7e4da6adf095ca5b84c0fd43595"},
+    {file = "orjson-3.10.5-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:b39e006b00c57125ab974362e740c14a0c6a66ff695bff44615dcf4a70ce2b86"},
+    {file = "orjson-3.10.5-cp39-none-win32.whl", hash = "sha256:eded5138cc565a9d618e111c6d5c2547bbdd951114eb822f7f6309e04db0fb47"},
+    {file = "orjson-3.10.5-cp39-none-win_amd64.whl", hash = "sha256:cc28e90a7cae7fcba2493953cff61da5a52950e78dc2dacfe931a317ee3d8de7"},
+    {file = "orjson-3.10.5.tar.gz", hash = "sha256:7a5baef8a4284405d96c90c7c62b755e9ef1ada84c2406c24a9ebec86b89f46d"},
 ]
 
 [[package]]
@@ -3860,13 +3860,13 @@ rdkit = ">=2023.3.2,<2024.0.0"
 
 [[package]]
 name = "redis"
-version = "5.0.5"
+version = "5.0.6"
 description = "Python client for Redis database and key-value store"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "redis-5.0.5-py3-none-any.whl", hash = "sha256:30b47d4ebb6b7a0b9b40c1275a19b87bb6f46b3bed82a89012cf56dea4024ada"},
-    {file = "redis-5.0.5.tar.gz", hash = "sha256:3417688621acf6ee368dec4a04dd95881be24efd34c79f00d31f62bb528800ae"},
+    {file = "redis-5.0.6-py3-none-any.whl", hash = "sha256:c0d6d990850c627bbf7be01c5c4cbaadf67b48593e913bb71c9819c30df37eee"},
+    {file = "redis-5.0.6.tar.gz", hash = "sha256:38473cd7c6389ad3e44a91f4c3eaf6bcb8a9f746007f29bf4fb20824ff0b2197"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ redis = "^5"
 splines = "^0.3"
 znsocket = "^0.1.6"
 lazy-loader = "^0.4"
+znjson = "^0.2.3"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ mdanalysis = {version = "^2", optional = true}
 tidynamics = {version = "^1", optional = true}
 rdkit2ase = {version = "^0.1", optional = true}
 zntrack = {version = "^0.7.3", optional = true}
-znframe = "^0.1"
 celery = "^5"
 sqlalchemy = "^2"
 redis = "^5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zndraw"
-version = "0.4.0a12"
+version = "0.4.0"
 description = "Display and Edit Molecular Structures and Trajectories in the Browser."
 authors = ["zincwarecode <zincwarecode@gmail.com>"]
 license = "License :: OSI Approved :: Eclipse Public License 2.0 (EPL-2.0)"

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -2,6 +2,7 @@ import numpy.testing as npt
 import pytest
 import znjson
 from ase.calculators.singlepoint import SinglePointCalculator
+import ase
 
 from zndraw.utils import ASEConverter
 
@@ -31,3 +32,13 @@ def test_ase_converter(s22):
     assert "radii" in structures[0].arrays
 
     assert structures[4].info == {"key": "value"}
+
+
+def test_exotic_atoms():
+    atoms = ase.Atoms("X", positions=[[0, 0, 0]])
+    new_atoms = znjson.loads(
+        znjson.dumps(atoms, cls=znjson.ZnEncoder.from_converters([ASEConverter])),
+        cls=znjson.ZnDecoder.from_converters([ASEConverter]),
+    )
+    npt.assert_array_equal(new_atoms.arrays["colors"], ['#ff0000'])
+    npt.assert_array_equal(new_atoms.arrays["radii"], [0.2])

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -1,3 +1,4 @@
+import numpy.testing as npt
 import pytest
 import znjson
 from ase.calculators.singlepoint import SinglePointCalculator
@@ -20,7 +21,7 @@ def test_ase_converter(s22):
     for s1, s2 in zip(s22, structures):
         assert s1 == s2
 
-    assert structures[0].connectivity == [[0, 1, 1], [1, 2, 1], [2, 3, 1]]
+    npt.assert_array_equal(structures[0].connectivity, [[0, 1, 1], [1, 2, 1], [2, 3, 1]])
     with pytest.raises(AttributeError):
         _ = structures[1].connectivity
 

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -1,5 +1,3 @@
-import json
-
 import pytest
 import znjson
 from ase.calculators.singlepoint import SinglePointCalculator
@@ -13,10 +11,10 @@ def test_ase_converter(s22):
     s22[3].calc.results = {"energy": 0.0, "predicted_energy": 1.0}
     s22[4].info = {"key": "value"}
 
-    structures_json = json.dumps(
+    structures_json = znjson.dumps(
         s22, cls=znjson.ZnEncoder.from_converters([ASEConverter])
     )
-    structures = json.loads(
+    structures = znjson.loads(
         structures_json, cls=znjson.ZnDecoder.from_converters([ASEConverter])
     )
     for s1, s2 in zip(s22, structures):

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -1,11 +1,34 @@
 import json
 
+import pytest
 import znjson
+from ase.calculators.singlepoint import SinglePointCalculator
 
 from zndraw.utils import ASEConverter
 
 
 def test_ase_converter(s22):
-    atoms_json = json.dumps(s22[0], cls=znjson.ZnEncoder.from_converters([ASEConverter]))
-    atoms = json.loads(atoms_json, cls=znjson.ZnDecoder.from_converters([ASEConverter]))
-    assert atoms == s22[0]
+    s22[0].connectivity = [[0, 1, 1], [1, 2, 1], [2, 3, 1]]
+    s22[3].calc = SinglePointCalculator(s22[3])
+    s22[3].calc.results = {"energy": 0.0, "predicted_energy": 1.0}
+    s22[4].info = {"key": "value"}
+
+    structures_json = json.dumps(
+        s22, cls=znjson.ZnEncoder.from_converters([ASEConverter])
+    )
+    structures = json.loads(
+        structures_json, cls=znjson.ZnDecoder.from_converters([ASEConverter])
+    )
+    for s1, s2 in zip(s22, structures):
+        assert s1 == s2
+
+    assert structures[0].connectivity == [[0, 1, 1], [1, 2, 1], [2, 3, 1]]
+    with pytest.raises(AttributeError):
+        _ = structures[1].connectivity
+
+    assert structures[3].calc.results == {"energy": 0.0, "predicted_energy": 1.0}
+
+    assert "colors" in structures[0].arrays
+    assert "radii" in structures[0].arrays
+
+    assert structures[4].info == {"key": "value"}

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -41,4 +41,4 @@ def test_exotic_atoms():
         cls=znjson.ZnDecoder.from_converters([ASEConverter]),
     )
     npt.assert_array_equal(new_atoms.arrays["colors"], ["#ff0000"])
-    npt.assert_array_equal(new_atoms.arrays["radii"], [0.2])
+    npt.assert_array_equal(new_atoms.arrays["radii"], [0.3])

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -1,0 +1,11 @@
+import json
+
+import znjson
+
+from zndraw.utils import ASEConverter
+
+
+def test_ase_converter(s22):
+    atoms_json = json.dumps(s22[0], cls=znjson.ZnEncoder.from_converters([ASEConverter]))
+    atoms = json.loads(atoms_json, cls=znjson.ZnDecoder.from_converters([ASEConverter]))
+    assert atoms == s22[0]

--- a/zndraw/base.py
+++ b/zndraw/base.py
@@ -7,11 +7,13 @@ from collections.abc import MutableSequence
 import ase
 import numpy as np
 import splines
-import znframe
+import znjson
 import znsocket
 from flask import current_app, session
 from pydantic import BaseModel, Field, create_model
 from redis import Redis
+
+from zndraw.utils import ASEConverter
 
 log = logging.getLogger(__name__)
 
@@ -42,7 +44,9 @@ class Extension(BaseModel):
         lst = znsocket.List(r, key)
         try:
             frame_json = lst[int(step)]
-            return znframe.Frame.from_json(frame_json).to_atoms()
+            return znjson.loads(
+                frame_json, cls=znjson.ZnDecoder.from_converters([ASEConverter])
+            )
         except TypeError:
             # step is None
             return ase.Atoms()

--- a/zndraw/bonds/__init__.py
+++ b/zndraw/bonds/__init__.py
@@ -47,8 +47,9 @@ class ASEComputeBonds(BaseModel):
         except NetworkXError:
             pass
 
-    def get_bonds(self, atoms: ase.Atoms):
-        graph = atoms.connectivity
+    def get_bonds(self, atoms: ase.Atoms, graph: nx.Graph = None):
+        if graph is None:
+            graph = self.build_graph(atoms)
         bonds = []
         for edge in graph.edges:
             bonds.append((edge[0], edge[1], graph.edges[edge]["weight"]))

--- a/zndraw/cli.py
+++ b/zndraw/cli.py
@@ -6,12 +6,11 @@ import os
 import typing as t
 
 import typer
-from celery import chain
 
 from zndraw.app import create_app
 from zndraw.base import FileIO
 from zndraw.standalone import run_celery_worker, run_znsocket
-from zndraw.tasks import compute_bonds, read_file
+from zndraw.tasks import read_file
 from zndraw.utils import get_port
 
 cli = typer.Typer()
@@ -123,10 +122,7 @@ def main(
 
     app = create_app()
 
-    # read_file.delay(fileio.to_dict())
-    # compute_bonds.delay()
-
-    chain(read_file.s(fileio.to_dict()), compute_bonds.s()).apply_async()
+    read_file.delay(fileio.to_dict())
 
     if browser:
         import webbrowser

--- a/zndraw/cli.py
+++ b/zndraw/cli.py
@@ -6,11 +6,12 @@ import os
 import typing as t
 
 import typer
+from celery import chain
 
 from zndraw.app import create_app
 from zndraw.base import FileIO
 from zndraw.standalone import run_celery_worker, run_znsocket
-from zndraw.tasks import read_file
+from zndraw.tasks import compute_bonds, read_file
 from zndraw.utils import get_port
 
 cli = typer.Typer()
@@ -122,7 +123,10 @@ def main(
 
     app = create_app()
 
-    read_file.delay(fileio.to_dict())
+    # read_file.delay(fileio.to_dict())
+    # compute_bonds.delay()
+
+    chain(read_file.s(fileio.to_dict()), compute_bonds.s()).apply_async()
 
     if browser:
         import webbrowser

--- a/zndraw/modify/__init__.py
+++ b/zndraw/modify/__init__.py
@@ -55,7 +55,7 @@ class Connect(UpdateScene):
         camera_position = np.array(vis.camera["position"])[None, :]  # 1,3
 
         new_points = atom_positions[atom_ids]  # N, 3
-        radii: np.ndarray = atoms.arrays["radii"][atom_ids]
+        radii: np.ndarray = atoms.arrays["radii"][atom_ids][:, None]
         direction = camera_position - new_points
         direction /= np.linalg.norm(direction, axis=1, keepdims=True)
         new_points += direction * radii
@@ -117,7 +117,8 @@ class Delete(UpdateScene):
         else:
             for idx, atom_id in enumerate(sorted(atom_ids)):
                 atoms.pop(atom_id - idx)  # we remove the atom and shift the index
-            del atoms.connectivity
+            if hasattr(atoms, "connectivity"):
+                del atoms.connectivity
         vis.append(atoms)
         vis.selection = []
         vis.step += 1

--- a/zndraw/modify/__init__.py
+++ b/zndraw/modify/__init__.py
@@ -8,7 +8,6 @@ import ase
 import numpy as np
 from ase.data import chemical_symbols
 from pydantic import Field
-from znframe.frame import get_radius
 
 from zndraw.base import Extension, MethodsCollection
 
@@ -50,13 +49,13 @@ class Connect(UpdateScene):
     """Create guiding curve between selected atoms."""
 
     def run(self, vis: "ZnDraw", **kwargs) -> None:
+        atoms = vis.atoms
         atom_ids = vis.selection
         atom_positions = vis.atoms.get_positions()
-        atom_numbers = vis.atoms.numbers[atom_ids]
         camera_position = np.array(vis.camera["position"])[None, :]  # 1,3
 
         new_points = atom_positions[atom_ids]  # N, 3
-        radii: np.ndarray = get_radius(atom_numbers)[0][:, None]  # N, 1
+        radii: np.ndarray = atoms.arrays["radii"][atom_ids]
         direction = camera_position - new_points
         direction /= np.linalg.norm(direction, axis=1, keepdims=True)
         new_points += direction * radii

--- a/zndraw/scene.py
+++ b/zndraw/scene.py
@@ -1,11 +1,13 @@
 import enum
 
 import ase
-import znframe
+import znjson
 import znsocket
 from flask import current_app, session
 from pydantic import BaseModel, Field
 from redis import Redis
+
+from zndraw.utils import ASEConverter
 
 
 class Material(str, enum.Enum):
@@ -74,7 +76,9 @@ class Scene(BaseModel):
         lst = znsocket.List(r, key)
         try:
             frame_json = lst[int(step)]
-            return znframe.Frame.from_json(frame_json).to_atoms()
+            return znjson.loads(
+                frame_json, cls=znjson.ZnDecoder.from_converters([ASEConverter])
+            )
         except TypeError:
             # step is None
             return ase.Atoms()

--- a/zndraw/tasks/__init__.py
+++ b/zndraw/tasks/__init__.py
@@ -4,12 +4,13 @@ import typing as t
 import ase.io
 import socketio.exceptions
 import tqdm
-import znframe
+import znjson
 import znsocket
 from celery import shared_task
 from flask import current_app
 
 from zndraw.base import FileIO
+from zndraw.utils import ASEConverter
 
 log = logging.getLogger(__name__)
 
@@ -77,8 +78,9 @@ def read_file(fileio: dict) -> None:
             break
         if file_io.step and idx % file_io.step != 0:
             continue
-        frame = znframe.Frame.from_atoms(atoms)
-        lst.append(frame.to_json())
+        lst.append(
+            znjson.dumps(atoms, cls=znjson.ZnEncoder.from_converters([ASEConverter]))
+        )
         if idx == 0:
             try:
                 io.connect(current_app.config["SERVER_URL"], wait_timeout=10)

--- a/zndraw/utils.py
+++ b/zndraw/utils.py
@@ -13,8 +13,8 @@ import datamodel_code_generator
 import numpy as np
 import socketio.exceptions
 from ase.calculators.singlepoint import SinglePointCalculator
+from ase.data import covalent_radii
 from ase.data.colors import jmol_colors
-from ase.data.vdw import vdw_radii
 from znjson import ConverterBase
 
 log = logging.getLogger(__name__)
@@ -99,7 +99,7 @@ class ASEConverter(ConverterBase):
             )
 
         if "radii" not in obj.arrays:
-            arrays["radii"] = [vdw_radii[number] for number in numbers]
+            arrays["radii"] = [covalent_radii[number] for number in numbers]
         else:
             arrays["radii"] = (
                 obj.arrays["radii"].tolist()
@@ -138,7 +138,10 @@ class ASEConverter(ConverterBase):
         )
         if connectivity := value.get("connectivity"):
             atoms.connectivity = connectivity
-        atoms.arrays.update(value["arrays"])
+        if "colors" in value["arrays"]:
+            atoms.arrays["colors"] = np.array(value["arrays"]["colors"])
+        if "radii" in value["arrays"]:
+            atoms.arrays["radii"] = np.array(value["arrays"]["radii"])
         if calc := value.get("calc"):
             atoms.calc = SinglePointCalculator(atoms)
             atoms.calc.results.update(calc)

--- a/zndraw/utils.py
+++ b/zndraw/utils.py
@@ -1,3 +1,4 @@
+import functools
 import importlib.util
 import json
 import logging
@@ -16,7 +17,6 @@ from ase.calculators.singlepoint import SinglePointCalculator
 from ase.data import covalent_radii
 from ase.data.colors import jmol_colors
 from znjson import ConverterBase
-import functools
 
 log = logging.getLogger(__name__)
 
@@ -36,6 +36,7 @@ def rgb2hex(value):
     r, g, b = np.array(value * 255, dtype=int)
     return "#%02x%02x%02x" % (r, g, b)
 
+
 @functools.lru_cache(maxsize=128)
 def get_scaled_radii() -> np.ndarray:
     """Scale down the covalent radii to visualize bonds better."""
@@ -45,6 +46,7 @@ def get_scaled_radii() -> np.ndarray:
     radii = radii / np.max(radii)
     radii = radii + 0.3
     return radii
+
 
 class ASEConverter(ConverterBase):
     """Encode/Decode datetime objects

--- a/zndraw/utils.py
+++ b/zndraw/utils.py
@@ -86,6 +86,8 @@ class ASEConverter(ConverterBase):
         else:
             calc = {}
 
+        # All additional information should be stored in calc.results
+        # and not in calc.arrays, thus we will not convert it here!
         arrays = {}
         if "colors" not in obj.arrays:
             arrays["colors"] = [rgb2hex(jmol_colors[number]) for number in numbers]

--- a/zndraw/utils.py
+++ b/zndraw/utils.py
@@ -137,7 +137,8 @@ class ASEConverter(ConverterBase):
             cell=value["cell"],
         )
         if connectivity := value.get("connectivity"):
-            atoms.connectivity = connectivity
+            # or do we want this to be nx.Graph?
+            atoms.connectivity = np.array(connectivity)
         if "colors" in value["arrays"]:
             atoms.arrays["colors"] = np.array(value["arrays"]["colors"])
         if "radii" in value["arrays"]:

--- a/zndraw/zndraw.py
+++ b/zndraw/zndraw.py
@@ -212,6 +212,9 @@ class ZnDraw(ZnDrawBase):
         )
 
     def insert(self, index: int, value: ase.Atoms):
+        if hasattr(value, "connectivity") and self.bond_calculator is not None:
+            value.connectivity = self.bond_calculator.get_bonds(value)
+
         call_with_retry(
             self.socket,
             "room:frames:insert",

--- a/zndraw/zndraw.py
+++ b/zndraw/zndraw.py
@@ -87,7 +87,7 @@ class ZnDraw(ZnDrawBase):
         default_factory=datetime.datetime.now
     )
 
-    bond_calculator: ASEComputeBonds = dataclasses.field(
+    bond_calculator: ASEComputeBonds|None = dataclasses.field(
         default_factory=ASEComputeBonds, repr=False
     )
 
@@ -178,7 +178,7 @@ class ZnDraw(ZnDrawBase):
 
         data = {}
         for i, val in zip(index, value):
-            if not hasattr(val, "connectivity"):
+            if not hasattr(val, "connectivity") and self.bond_calculator is not None:
                 val.connectivity = self.bond_calculator.get_bonds(val)
             data[i] = znjson.dumps(val, cls=znjson.ZnEncoder.from_converters([ASEConverter]))
 
@@ -243,7 +243,7 @@ class ZnDraw(ZnDrawBase):
         )
 
         for i, val in enumerate(tbar, start=len(self)):
-            if not hasattr(val, "connectivity"):
+            if not hasattr(val, "connectivity") and self.bond_calculator is not None:
                 val.connectivity = self.bond_calculator.get_bonds(val)
 
             msg[i] = znjson.dumps(

--- a/zndraw/zndraw.py
+++ b/zndraw/zndraw.py
@@ -155,7 +155,9 @@ class ZnDraw(ZnDrawBase):
         )
 
         structures = [
-            znjson.loads(x, cls=znjson.ZnDecoder.from_converters([ASEConverter]))
+            znjson.loads(
+                json.dumps(x), cls=znjson.ZnDecoder.from_converters([ASEConverter])
+            )
             for x in data.values()
         ]
         return structures[0] if single_item else structures


### PR DESCRIPTION
This PR replace the use of the `znframe` package with a definition on how to convert / read `ase.Atoms` from json strings through the use of znjson.

- Bond calculation through `vis` is now optional by setting `vis.bonds_calculator=None`.
- radii are now a rescaled version of `covalent_radii` from `ase`



# Old ideas
Thereby I also looked into making computing the bonds optional.
Bonds computation can be expensive, thus loading the trajectory and visualizing it first and adding the bonds afterwards would be my prioritized way of doing things. We could use two celery workers for this:
1. start read
2. whilst still reading already process what is in the db. (on rare occasions this could be faster than 1. thus we need 3)
3. After reading has finished, run another worker to check if all bonds have been computed.

Where do we want to define if bonds should be computed? E.b. `ZnDraw(bonds=True)`? Via the CLI?


Further this PR now uses `covalent_radii` from ase. VdW are too large, even `covalent` look a bit weird compared to what we had before.

- [ ] test types after `znjson.loads`
- [ ] test `inf` data file reading

