### PR TITLE
Test on windows and macos

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,6 +19,8 @@ jobs:
           - "3.10"
         os:
           - ubuntu-latest
+          - windows-latest
+          - macos-latest
 
     services:
       # Label used to access the service container


### PR DESCRIPTION
- [ ] test macos and windows with `znsocket` instead of `redis`