### PR TITLE
Add ZnDrawLocal functions and _repr_html_ for jupyter

### DIFF
--- a/zndraw/zndraw.py
+++ b/zndraw/zndraw.py
@@ -201,11 +201,12 @@ class ZnDraw(ZnDrawBase):
 
     def _repr_html_(self):
         from IPython.display import IFrame
+
         address = f"{self.url}/token/{self.token}"
         # TODO: save address and do not replace in post_init
         address = address.replace("ws", "http")
         print(f"Opening ZnDraw at {address}")
-        return IFrame(address, 1200,600)._repr_html_()
+        return IFrame(address, 1200, 600)._repr_html_()
 
     def insert(self, index: int, value: ase.Atoms):
         if not hasattr(value, "connectivity") and self.bond_calculator is not None:
@@ -570,19 +571,17 @@ class ZnDrawLocal(ZnDraw):
         return structures
 
     def insert_local(self, index: int, value: dict):
-
         lst = znsocket.List(self.r, f"room:{self.token}:frames")
         if not self.r.exists(f"room:{self.token}:frames"):
             default_lst = znsocket.List(self.r, "room:default:frames")
-            #TODO: using a redis copy action would be faster
+            # TODO: using a redis copy action would be faster
             lst.extend(default_lst)
         lst.insert(index, value)
 
     def append_local(self, value: dict):
-
         lst = znsocket.List(self.r, f"room:{self.token}:frames")
         if not self.r.exists(f"room:{self.token}:frames"):
             default_lst = znsocket.List(self.r, "room:default:frames")
-            #TODO: using a redis copy action would be faster
+            # TODO: using a redis copy action would be faster
             lst.extend(default_lst)
         lst.append(value)

--- a/zndraw/zndraw.py
+++ b/zndraw/zndraw.py
@@ -205,8 +205,8 @@ class ZnDraw(ZnDrawBase):
         address = f"{self.url}/token/{self.token}"
         # TODO: save address and do not replace in post_init
         address = address.replace("ws", "http")
-        print(f"Opening ZnDraw at {address}")
-        return IFrame(address, 1200, 600)._repr_html_()
+        log.info(f"Opening ZnDraw at {address}")
+        return IFrame(address, width="70%", height=600)._repr_html_()
 
     def insert(self, index: int, value: ase.Atoms):
         if not hasattr(value, "connectivity") and self.bond_calculator is not None:
@@ -570,7 +570,7 @@ class ZnDrawLocal(ZnDraw):
             return structures[0]
         return structures
 
-    def insert_local(self, index: int, value: dict):
+    def insert(self, index: int, value: dict):
         lst = znsocket.List(self.r, f"room:{self.token}:frames")
         if not self.r.exists(f"room:{self.token}:frames"):
             default_lst = znsocket.List(self.r, "room:default:frames")
@@ -578,7 +578,7 @@ class ZnDrawLocal(ZnDraw):
             lst.extend(default_lst)
         lst.insert(index, value)
 
-    def append_local(self, value: dict):
+    def append(self, value: dict):
         lst = znsocket.List(self.r, f"room:{self.token}:frames")
         if not self.r.exists(f"room:{self.token}:frames"):
             default_lst = znsocket.List(self.r, "room:default:frames")

--- a/zndraw/zndraw.py
+++ b/zndraw/zndraw.py
@@ -38,6 +38,9 @@ class TimeoutConfig(t.TypedDict):
     call_retries: int
     connect_retries: int
 
+class JupyterConfig(t.TypedDict):  
+    width: str|int
+    height: str|int
 
 class CameraData(t.TypedDict):
     position: list[float]
@@ -78,6 +81,13 @@ class ZnDraw(ZnDrawBase):
             connect_retries=3,
         )
     )
+    jupyter_config: JupyterConfig = dataclasses.field(
+        default_factory=lambda: JupyterConfig(
+            width="70%",
+            height=600,
+        )
+    )
+
     maximum_message_size: int = dataclasses.field(default=500_000, repr=False)
 
     _modifiers: dict[str, RegisterModifier] = dataclasses.field(default_factory=dict)
@@ -206,7 +216,7 @@ class ZnDraw(ZnDrawBase):
         # TODO: save address and do not replace in post_init
         address = address.replace("ws", "http")
         log.info(f"Opening ZnDraw at {address}")
-        return IFrame(address, width="70%", height=600)._repr_html_()
+        return IFrame(address, width=self.jupyter_config["width"], height=self.jupyter_config["height"])._repr_html_()
 
     def insert(self, index: int, value: ase.Atoms):
         if not hasattr(value, "connectivity") and self.bond_calculator is not None:

--- a/zndraw/zndraw.py
+++ b/zndraw/zndraw.py
@@ -38,9 +38,11 @@ class TimeoutConfig(t.TypedDict):
     call_retries: int
     connect_retries: int
 
-class JupyterConfig(t.TypedDict):  
-    width: str|int
-    height: str|int
+
+class JupyterConfig(t.TypedDict):
+    width: str | int
+    height: str | int
+
 
 class CameraData(t.TypedDict):
     position: list[float]
@@ -216,7 +218,11 @@ class ZnDraw(ZnDrawBase):
         # TODO: save address and do not replace in post_init
         address = address.replace("ws", "http")
         log.info(f"Opening ZnDraw at {address}")
-        return IFrame(address, width=self.jupyter_config["width"], height=self.jupyter_config["height"])._repr_html_()
+        return IFrame(
+            address,
+            width=self.jupyter_config["width"],
+            height=self.jupyter_config["height"],
+        )._repr_html_()
 
     def insert(self, index: int, value: ase.Atoms):
         if not hasattr(value, "connectivity") and self.bond_calculator is not None:

--- a/zndraw/zndraw.py
+++ b/zndraw/zndraw.py
@@ -199,6 +199,14 @@ class ZnDraw(ZnDrawBase):
             retries=self.timeout["call_retries"],
         )
 
+    def _repr_html_(self):
+        from IPython.display import IFrame
+        address = f"{self.url}/token/{self.token}"
+        # TODO: save address and do not replace in post_init
+        address = address.replace("ws", "http")
+        print(f"Opening ZnDraw at {address}")
+        return IFrame(address, 1200,600)._repr_html_()
+
     def insert(self, index: int, value: ase.Atoms):
         if not hasattr(value, "connectivity") and self.bond_calculator is not None:
             value.connectivity = self.bond_calculator.get_bonds(value)
@@ -560,3 +568,21 @@ class ZnDrawLocal(ZnDraw):
         if single_item:
             return structures[0]
         return structures
+
+    def insert_local(self, index: int, value: dict):
+
+        lst = znsocket.List(self.r, f"room:{self.token}:frames")
+        if not self.r.exists(f"room:{self.token}:frames"):
+            default_lst = znsocket.List(self.r, "room:default:frames")
+            #TODO: using a redis copy action would be faster
+            lst.extend(default_lst)
+        lst.insert(index, value)
+
+    def append_local(self, value: dict):
+
+        lst = znsocket.List(self.r, f"room:{self.token}:frames")
+        if not self.r.exists(f"room:{self.token}:frames"):
+            default_lst = znsocket.List(self.r, "room:default:frames")
+            #TODO: using a redis copy action would be faster
+            lst.extend(default_lst)
+        lst.append(value)


### PR DESCRIPTION
Add `insert` and `append`-functions for the `ZnDrawLocal`-class for faster local use.

Add `_repr_html_`-function to display a embedded browser window in jupyter when the `ZnDraw`-class is called.