### PR TITLE
Fix euler angle conversion bug

### DIFF
--- a/zndraw/utils.py
+++ b/zndraw/utils.py
@@ -329,11 +329,11 @@ def direction_to_euler(direction, roll=0):
 
     if x == 0 and y == 0:
         if z > 0:
-            yaw = 0
-            pitch = 0
+            yaw = 0.0
+            pitch = 0.0
         else:
-            yaw = 0
-            pitch = 180
+            yaw = 0.0
+            pitch = np.pi
     else:
         yaw = np.arctan2(y, x)
         pitch = np.arctan2(z, np.sqrt(x**2 + y**2))


### PR DESCRIPTION
The function `direction_to_euler` had two bugs.
- Returned integers in a special case, which could cause problems when using them for calculations later.
- One value was returned in degrees instead of radians