### PR TITLE
fix backwards compatibility issue

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -582,13 +582,14 @@ export default function App() {
             decay={0}
             intensity={Math.PI}
             castShadow
-          /> 
-          {sceneSettings["vectorfield"] && currentFrame.vectors !== undefined && (
-            <VectorField
-              vectors={currentFrame.vectors}
-              arrowsConfig={arrowsConfig}
-            />
-          )}
+          />
+          {sceneSettings["vectorfield"] &&
+            currentFrame.vectors !== undefined && (
+              <VectorField
+                vectors={currentFrame.vectors}
+                arrowsConfig={arrowsConfig}
+              />
+            )}
           <ParticleInstances
             frame={currentFrame}
             selectedIds={selectedIds}

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -582,8 +582,8 @@ export default function App() {
             decay={0}
             intensity={Math.PI}
             castShadow
-          />
-          {sceneSettings["vectorfield"] && (
+          /> 
+          {sceneSettings["vectorfield"] && currentFrame.vectors !== undefined && (
             <VectorField
               vectors={currentFrame.vectors}
               arrowsConfig={arrowsConfig}

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -105,7 +105,7 @@ export default function App() {
     colormap: [[0, 0, 0.5]],
     colorrange: [0, 1],
     normalize: true,
-    scale_vector_thickness: true,
+    scale_vector_thickness: false,
     opacity: 1.0,
   });
 

--- a/zndraw/server/events.py
+++ b/zndraw/server/events.py
@@ -119,7 +119,7 @@ def init_socketio_events(io: SocketIO):
                         "colormap": [[-0.5, 0.9, 0.5], [0.0, 0.9, 0.5]],
                         "normalize": True,
                         "colorrange": [0, 1],
-                        "scale_vector_thickness": True,
+                        "scale_vector_thickness": False,
                         "opacity": 1.0,
                     }
                 ),


### PR DESCRIPTION
There was an issue causing JS to crash if `vectors` was not sent to the server. Also change defaults.