### PR TITLE
Test `vis.append` types

### DIFF
--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -49,6 +49,8 @@ def test_append_faulty(ref, request):
     data = ASEConverter().encode(water)
     with pytest.raises(ValueError, match="Unable to parse provided data object"):
         vis.append(data)
+    with pytest.raises(ValueError, match="Unable to parse provided data object"):
+        vis.extend(3.14)
 
 
 @pytest.mark.parametrize("ref", ["full", "local"])
@@ -87,3 +89,41 @@ def test_setitem_faulty(ref, request, s22):
     data = ASEConverter().encode(water)
     with pytest.raises(ValueError, match="Unable to parse provided data object"):
         vis[0] = data
+    with pytest.raises(ValueError, match="Unable to parse provided data object"):
+        vis.extend(3.14)
+
+
+@pytest.mark.parametrize("ref", ["full", "local"])
+def test_extend_atoms(ref, request, s22):
+    """Test the server fixture."""
+    vis = request.getfixturevalue(ref)
+    vis.extend(s22)
+    assert vis[:] == s22
+
+
+@pytest.mark.parametrize("ref", ["local", "full"])
+def test_extend_dump(ref, request, s22):
+    """Test the server fixture."""
+    vis = request.getfixturevalue(ref)
+
+    data = [znjson.dumps(s, cls=znjson.ZnEncoder.from_converters(ASEConverter)) for s in s22]
+    vis.extend(data)
+    assert vis[:] == s22
+
+
+@pytest.mark.parametrize("ref", ["full", "local"])
+def test_extend_faulty(ref, request, s22):
+    """Test the server fixture."""
+    vis = request.getfixturevalue(ref)
+    vis.extend(s22)
+
+    with pytest.raises(ValueError, match="Unable to parse provided data object"):
+        vis.extend(znjson.dumps(s22, cls=znjson.ZnEncoder.from_converters(ASEConverter)))
+    
+    data = [ASEConverter().encode(s) for s in s22]
+
+    with pytest.raises(ValueError, match="Unable to parse provided data object"):
+        vis.extend(data)
+
+    with pytest.raises(ValueError, match="Unable to parse provided data object"):
+        vis.extend(3.14)

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -49,3 +49,41 @@ def test_append_faulty(ref, request):
     data = ASEConverter().encode(water)
     with pytest.raises(ValueError, match="Unable to parse provided data object"):
         vis.append(data)
+
+
+@pytest.mark.parametrize("ref", ["full", "local"])
+def test_setitem_atoms(ref, request, s22):
+    """Test the server fixture."""
+    vis = request.getfixturevalue(ref)
+    vis.extend(s22)
+    water = molecule("H2O")
+    vis[0] = water
+    assert vis[0] == water
+
+    vis[[1, 2]] = [water, water]
+    assert vis[[0, 1, 2]] == [water, water, water]
+
+
+@pytest.mark.parametrize("ref", ["local", "full"])
+def test_setitem_dump(ref, request, s22):
+    """Test the server fixture."""
+    vis = request.getfixturevalue(ref)
+    vis.extend(s22)
+    water = molecule("H2O")
+    vis[0] = znjson.dumps(water, cls=znjson.ZnEncoder.from_converters(ASEConverter))
+    assert vis[0] == molecule("H2O")
+
+    vis[[1, 2]] = [water, water]
+    assert vis[[0, 1, 2]] == [water, water, water]
+
+
+@pytest.mark.parametrize("ref", ["full", "local"])
+def test_setitem_faulty(ref, request, s22):
+    """Test the server fixture."""
+    vis = request.getfixturevalue(ref)
+    vis.extend(s22)
+
+    water = molecule("H2O")
+    data = ASEConverter().encode(water)
+    with pytest.raises(ValueError, match="Unable to parse provided data object"):
+        vis[0] = data

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -1,0 +1,51 @@
+from ase.build import molecule
+
+from zndraw import ZnDraw, ZnDrawLocal
+from zndraw.utils import ASEConverter
+from zndraw.type_defs import ASEDict
+import znjson
+import redis
+import pytest
+
+
+@pytest.fixture
+def full(server):
+    return ZnDraw(url=server, token="test_token")
+
+@pytest.fixture
+def local(server):
+    r = redis.Redis.from_url("redis://localhost:6379/0")
+
+    return ZnDrawLocal(url=server, token="test_token", r=r)
+
+
+@pytest.mark.parametrize("ref", ["full", "local"])
+def test_append_atoms(ref, request):
+    """Test the server fixture."""
+    vis = request.getfixturevalue(ref)
+    water = molecule("H2O")
+    vis.append(water)
+
+    assert vis[-1] == water
+
+
+@pytest.mark.parametrize("ref", ["full", "local"])
+def test_append_dump(ref, request):
+    """Test the server fixture."""
+    vis = request.getfixturevalue(ref)
+
+    water = molecule("H2O")
+    vis.append(znjson.dumps(water, cls=znjson.ZnEncoder.from_converters(ASEConverter)))
+
+    assert vis[-1] == water
+
+
+@pytest.mark.parametrize("ref", ["full", "local"])
+def test_append_faulty(ref, request):
+    """Test the server fixture."""
+    vis = request.getfixturevalue(ref)
+
+    water = molecule("H2O")
+    data = ASEConverter().encode(water)
+    with pytest.raises(ValueError, match="Unable to parse provided data object"):
+        vis.append(data)

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -1,16 +1,16 @@
+import pytest
+import redis
+import znjson
 from ase.build import molecule
 
 from zndraw import ZnDraw, ZnDrawLocal
 from zndraw.utils import ASEConverter
-from zndraw.type_defs import ASEDict
-import znjson
-import redis
-import pytest
 
 
 @pytest.fixture
 def full(server):
     return ZnDraw(url=server, token="test_token")
+
 
 @pytest.fixture
 def local(server):

--- a/zndraw/__init__.pyi
+++ b/zndraw/__init__.pyi
@@ -17,10 +17,11 @@ from .draw import (
     Torus,
     TorusKnot,
 )
-from .zndraw import ZnDraw
+from .zndraw import ZnDraw, ZnDrawLocal
 
 __all__ = [
     "ZnDraw",
+    "ZnDrawLocal",
     "Extension",
     "Plane",
     "Sphere",

--- a/zndraw/type_defs.py
+++ b/zndraw/type_defs.py
@@ -45,9 +45,11 @@ class ASEDict(t.TypedDict):
     cell: list[list[float]]
     vectors: list[list[list[float]]]
 
+
 class ASEJson(t.TypedDict):
     _type: t.Literal["ase.Atoms"]
     value: ASEDict
+
 
 # Type hint is string, but correctly it is 'json.dumps(ASEJson)'
 ATOMS_LIKE = t.Union[ASEDict, str]

--- a/zndraw/type_defs.py
+++ b/zndraw/type_defs.py
@@ -44,3 +44,10 @@ class ASEDict(t.TypedDict):
     pbc: list[bool]
     cell: list[list[float]]
     vectors: list[list[list[float]]]
+
+class ASEJson(t.TypedDict):
+    _type: t.Literal["ase.Atoms"]
+    value: ASEDict
+
+# Type hint is string, but correctly it is 'json.dumps(ASEJson)'
+ATOMS_LIKE = t.Union[ASEDict, str]

--- a/zndraw/type_defs.py
+++ b/zndraw/type_defs.py
@@ -1,0 +1,46 @@
+import typing as t
+
+if t.TYPE_CHECKING:
+    from zndraw.base import Extension
+
+
+class RegisterModifier(t.TypedDict):
+    cls: t.Type["Extension"]
+    run_kwargs: dict
+    public: bool
+    frozen: bool
+    timeout: float
+
+
+class TimeoutConfig(t.TypedDict):
+    """Timeout configuration for the ZnDraw client."""
+
+    connection: int
+    modifier: float
+    between_calls: float
+
+    emit_retries: int
+    call_retries: int
+    connect_retries: int
+
+
+class JupyterConfig(t.TypedDict):
+    width: str | int
+    height: str | int
+
+
+class CameraData(t.TypedDict):
+    position: list[float]
+    target: list[float]
+
+
+class ASEDict(t.TypedDict):
+    numbers: list[int]
+    positions: list[list[float]]
+    connectivity: list[tuple[int, int, int]]
+    arrays: dict[str, list[float | int | list[float | int]]]
+    info: dict[str, float | int]
+    # calc: dict[str, float|int|np.ndarray] # should this be split into arrays and info?
+    pbc: list[bool]
+    cell: list[list[float]]
+    vectors: list[list[list[float]]]

--- a/zndraw/utils.py
+++ b/zndraw/utils.py
@@ -18,19 +18,9 @@ from ase.data import covalent_radii
 from ase.data.colors import jmol_colors
 from znjson import ConverterBase
 
+from zndraw.type_defs import ASEDict
+
 log = logging.getLogger(__name__)
-
-
-class ASEDict(t.TypedDict):
-    numbers: list[int]
-    positions: list[list[float]]
-    connectivity: list[tuple[int, int, int]]
-    arrays: dict[str, list[float | int | list[float | int]]]
-    info: dict[str, float | int]
-    # calc: dict[str, float|int|np.ndarray] # should this be split into arrays and info?
-    pbc: list[bool]
-    cell: list[list[float]]
-    vectors: list[list[list[float]]]
 
 
 def rgb2hex(value):

--- a/zndraw/zndraw.py
+++ b/zndraw/zndraw.py
@@ -613,7 +613,7 @@ class ZnDrawLocal(ZnDraw):
     def extend(self, values: list[ATOMS_LIKE]):
         if not isinstance(values, list):
             raise ValueError("Unable to parse provided data object")
-        
+
         # enable tbar if more than 10 messages are sent
         # approximated by the size of the first frame
         lst = znsocket.List(self.r, f"room:{self.token}:frames")
@@ -636,9 +636,11 @@ class ZnDrawLocal(ZnDraw):
                 if not hasattr(val, "connectivity") and self.bond_calculator is not None:
                     val.connectivity = self.bond_calculator.get_bonds(val)
 
-                msg.append(znjson.dumps(
-                    val, cls=znjson.ZnEncoder.from_converters([ASEConverter])
-                ))
+                msg.append(
+                    znjson.dumps(
+                        val, cls=znjson.ZnEncoder.from_converters([ASEConverter])
+                    )
+                )
             else:
                 msg.append(val)
             if '"_type": "ase.Atoms"' not in msg[-1]:

--- a/zndraw/zndraw.py
+++ b/zndraw/zndraw.py
@@ -15,39 +15,10 @@ from zndraw.base import Extension, ZnDrawBase
 from zndraw.bonds import ASEComputeBonds
 from zndraw.config import ArrowsConfig, ZnDrawConfig
 from zndraw.draw import Geometry, Object3D
+from zndraw.type_defs import CameraData, JupyterConfig, RegisterModifier, TimeoutConfig
 from zndraw.utils import ASEConverter, call_with_retry, emit_with_retry
 
 log = logging.getLogger(__name__)
-
-
-class RegisterModifier(t.TypedDict):
-    cls: t.Type[Extension]
-    run_kwargs: dict
-    public: bool
-    frozen: bool
-    timeout: float
-
-
-class TimeoutConfig(t.TypedDict):
-    """Timeout configuration for the ZnDraw client."""
-
-    connection: int
-    modifier: float
-    between_calls: float
-
-    emit_retries: int
-    call_retries: int
-    connect_retries: int
-
-
-class JupyterConfig(t.TypedDict):
-    width: str | int
-    height: str | int
-
-
-class CameraData(t.TypedDict):
-    position: list[float]
-    target: list[float]
 
 
 def _register_modifier(vis: "ZnDraw", data: RegisterModifier) -> None:

--- a/zndraw/zndraw.py
+++ b/zndraw/zndraw.py
@@ -15,7 +15,13 @@ from zndraw.base import Extension, ZnDrawBase
 from zndraw.bonds import ASEComputeBonds
 from zndraw.config import ArrowsConfig, ZnDrawConfig
 from zndraw.draw import Geometry, Object3D
-from zndraw.type_defs import CameraData, JupyterConfig, RegisterModifier, TimeoutConfig, ATOMS_LIKE
+from zndraw.type_defs import (
+    ATOMS_LIKE,
+    CameraData,
+    JupyterConfig,
+    RegisterModifier,
+    TimeoutConfig,
+)
 from zndraw.utils import ASEConverter, call_with_retry, emit_with_retry
 
 log = logging.getLogger(__name__)
@@ -201,11 +207,10 @@ class ZnDraw(ZnDrawBase):
             if not hasattr(value, "connectivity") and self.bond_calculator is not None:
                 value.connectivity = self.bond_calculator.get_bonds(value)
 
-        
             value = znjson.dumps(
                 value, cls=znjson.ZnEncoder.from_converters([ASEConverter])
             )
-        
+
         if '"_type": "ase.Atoms"' not in value:
             raise ValueError("Unable to parse provided data object")
 
@@ -584,12 +589,14 @@ class ZnDrawLocal(ZnDraw):
         if isinstance(value, ase.Atoms):
             if not hasattr(value, "connectivity") and self.bond_calculator is not None:
                 value.connectivity = self.bond_calculator.get_bonds(value)
-            
-            value = znjson.dumps(value, cls=znjson.ZnEncoder.from_converters([ASEConverter]))
+
+            value = znjson.dumps(
+                value, cls=znjson.ZnEncoder.from_converters([ASEConverter])
+            )
 
         if '"_type": "ase.Atoms"' not in value:
             raise ValueError("Unable to parse provided data object")
-        
+
         lst.insert(index, value)
 
     def __setitem__(


### PR DESCRIPTION
Check that the data passed to `vis.append` and other `vis` functions is correct.

- removed `ZnDrawLocal.append` because it uses `ZnDrawLocal.insert`
- allow for `ASEJson|ase.Atoms`
- add tests for many scenarios