### PR TITLE
[plotly] jump to custom data index if available

### DIFF
--- a/app/src/components/sidebar.tsx
+++ b/app/src/components/sidebar.tsx
@@ -230,7 +230,12 @@ const PlotsCard = ({
     event: MouseEvent;
     points: any[];
   }) => {
-    setStep(points[0].pointIndex);
+    console.log(points[0]);
+    if (points[0].customdata) {
+      setStep(points[0].customdata[0]);
+    } else {
+      setStep(points[0].pointIndex);
+    }
   };
 
   return (

--- a/app/src/components/sidebar.tsx
+++ b/app/src/components/sidebar.tsx
@@ -230,7 +230,6 @@ const PlotsCard = ({
     event: MouseEvent;
     points: any[];
   }) => {
-    console.log(points[0]);
     if (points[0].customdata) {
       setStep(points[0].customdata[0]);
     } else {


### PR DESCRIPTION
If you provide `customdata`, e.g. via

```python
l1 = pd.DataFrame({"x": [1, 2, 3], "y": [0, 1, 2], "idx": [0, 1, 2], "line_id": "line_1"})
l2 = pd.DataFrame({"x": [1, 2, 3], "y": [0.5, 1.5, 2.5], "idx": [3, 4, 5], "line_id": "line_2"})

# Combine the DataFrames
df = pd.concat([l1, l2])

# Plotting the lines
fig = px.line(df, x="x", y="y", color="line_id", hover_data=["idx"])
vis.figure = fig.to_json()
```

plotly will jump to the `first` item in `customdata` instead of the `pointIndex`.