### PR TITLE
Stop playback when scrubbing frames

### DIFF
--- a/app/src/components/ProgressBar.tsx
+++ b/app/src/components/ProgressBar.tsx
@@ -44,6 +44,8 @@ const FrameProgressBar = () => {
 		synchronizedMode,
 		setSynchronizedMode,
 		getIsFetching,
+		playing,
+		setPlaying,
 	} = useAppStore();
 
 	const { setStep, remoteLocked } = useStepControl();
@@ -74,6 +76,10 @@ const FrameProgressBar = () => {
 
 	// This is the primary handler for the slider
 	const handleSliderChange = (_e: Event, newFrame: number | number[]) => {
+		// Stop playback when scrubbing
+		if (playing) {
+			setPlaying(false);
+		}
 		// Apply snap-to-selected-frame logic if filtering is enabled
 		const snappedFrame = findNearestSelectedFrame(newFrame as number);
 		setStep(snappedFrame);
@@ -134,6 +140,10 @@ const FrameProgressBar = () => {
 	const handleInputSubmit = () => {
 		const newFrame = parseInt(inputValue, 10);
 		if (!isNaN(newFrame) && newFrame >= 0 && newFrame <= frameCount - 1) {
+			// Stop playback when manually setting frame
+			if (playing) {
+				setPlaying(false);
+			}
 			setStep(newFrame);
 		} else {
 			setInputValue(currentFrame.toString());
@@ -161,6 +171,14 @@ const FrameProgressBar = () => {
 		if (!isNaN(value) && value > 0) {
 			setSkipFrames(value);
 		}
+	};
+
+	// Bookmark click handler - stops playback and jumps to frame
+	const handleBookmarkClick = (frame: number) => {
+		if (playing) {
+			setPlaying(false);
+		}
+		setStep(frame);
 	};
 
 	const renderConnectionStatus = () => {
@@ -248,7 +266,7 @@ const FrameProgressBar = () => {
 					frameCount={frameCount}
 					currentFrame={currentFrame}
 					containerWidth={sliderWidth}
-					onBookmarkClick={setStep}
+					onBookmarkClick={handleBookmarkClick}
 					onBookmarkDelete={deleteBookmark}
 					onBookmarkEdit={addBookmark}
 				/>

--- a/app/src/hooks/useSocketManager.ts
+++ b/app/src/hooks/useSocketManager.ts
@@ -51,6 +51,7 @@ export const useSocketManager = (options: SocketManagerOptions = {}) => {
 		addProgressTracker,
 		updateProgressTracker,
 		removeProgressTracker,
+		setPlaying,
 	} = useAppStore();
 	const queryClient = useQueryClient();
 	const { openWindow } = useWindowManagerStore();
@@ -134,6 +135,8 @@ export const useSocketManager = (options: SocketManagerOptions = {}) => {
 
 		function onFrameUpdate(data: any) {
 			const { frame } = data;
+			// Stop playback when another client (e.g., Python) changes the frame
+			setPlaying(false);
 			setCurrentFrame(frame);
 		}
 
@@ -663,6 +666,7 @@ export const useSocketManager = (options: SocketManagerOptions = {}) => {
 		setConnected,
 		setFrameCount,
 		setCurrentFrame,
+		setPlaying,
 		queryClient,
 		setBookmarks,
 		setSelections,


### PR DESCRIPTION
Scrubbing (navigating frames via slider, input, bookmarks, or remote clients) now automatically stops playback to prevent conflicts between manual navigation and automatic frame advancement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Playback now automatically stops when scrubbing the timeline
  * Playback pauses when manually entering frame numbers
  * Playback stops when clicking bookmarks
  * Playback halts upon receiving frame updates from the server

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->