### PR TITLE
fix: refactor user Redis keys to prevent WRONGTYPE error in admin panel

### DIFF
--- a/src/zndraw/services/user_service.py
+++ b/src/zndraw/services/user_service.py
@@ -408,12 +408,11 @@ class UserService:
         """
         users = []
 
-        # Scan for all user keys
-        for key in self.r.scan_iter(match="user:*"):
-            # Extract userName from key
+        # Scan for all user data keys (users:data:*)
+        for key in self.r.scan_iter(match=UserKeys.data_pattern()):
             if isinstance(key, bytes):
                 key = key.decode("utf-8")
-            user_name = key.replace("user:", "")
+            user_name = UserKeys.username_from_data_key(key)
 
             # Get user data
             keys = UserKeys(user_name)

--- a/tests/test_auth_integration.py
+++ b/tests/test_auth_integration.py
@@ -192,6 +192,8 @@ def test_python_client_auto_login(server):
 
 def test_user_session_persists_in_redis(server, redis_client):
     """Test that user session data is stored in Redis after login."""
+    from zndraw.app.redis_keys import UserKeys
+
     username = "redis-test-user"
 
     # Login
@@ -201,11 +203,11 @@ def test_user_session_persists_in_redis(server, redis_client):
     user_name = data["userName"]
 
     # Check Redis for user session
-    user_key = f"user:{user_name}"
-    assert redis_client.exists(user_key) == 1
+    keys = UserKeys(user_name)
+    assert redis_client.exists(keys.hash_key()) == 1
 
     # Verify stored data
-    user_data = redis_client.hgetall(user_key)
+    user_data = redis_client.hgetall(keys.hash_key())
     assert user_data["userName"] == username
     assert "createdAt" in user_data
     assert "lastLogin" in user_data

--- a/tests/test_room_management.py
+++ b/tests/test_room_management.py
@@ -785,6 +785,8 @@ def test_admin_mode_admin_user_sees_all_rooms(
     server_admin_mode, s22, get_jwt_auth_headers
 ):
     """Test that admin users see all rooms regardless of visits."""
+    from zndraw.app.redis_keys import UserKeys
+
     # Admin username from conftest.py
     admin_username = "test-admin"
 
@@ -800,7 +802,8 @@ def test_admin_mode_admin_user_sees_all_rooms(
 
     # Grant admin to self (this happens via admin login flow)
     r = redis.Redis(host="localhost", port=6379, decode_responses=True)
-    r.set(f"admin:user:{admin_username}", "1")
+    keys = UserKeys(admin_username)
+    r.set(keys.admin_key(), "1")
 
     # Now admin should see all rooms
     response = requests.get(f"{server}/api/rooms", headers=admin_headers)


### PR DESCRIPTION
The list_all_users method was scanning user:* which also matched user:{username}:visited_rooms keys (Redis Sets). Calling hgetall() on Sets causes WRONGTYPE errors.

Refactored key structure to users:{type}:{username} format:
- users:data:{username} - user data hash
- users:admin:{username} - admin status
- users:visited:{username} - visited rooms set

This allows efficient scanning of users:data:* without conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved consistency of internal data handling mechanisms across multiple backend services to enhance reliability and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->