### PR TITLE
Add __repr__ and __str__ to Selections class

### DIFF
--- a/src/zndraw/zndraw.py
+++ b/src/zndraw/zndraw.py
@@ -130,6 +130,24 @@ class Selections:
         data = self.vis.api.get_all_selections()
         return len(data["selections"])
 
+    def __repr__(self) -> str:
+        """Return string representation of selections."""
+        data = self.vis.api.get_all_selections()
+        selections = data.get("selections", {})
+        parts = []
+        for geom in sorted(selections.keys()):
+            indices = selections[geom]
+            if len(indices) <= 5:
+                parts.append(f"{geom!r}: {indices!r}")
+            else:
+                preview = indices[:3]
+                parts.append(f"{geom!r}: {preview!r}... ({len(indices)} items)")
+        return f"Selections({{{', '.join(parts)}}})"
+
+    def __str__(self) -> str:
+        """Return string representation of selections."""
+        return self.__repr__()
+
 
 class SelectionGroups:
     """Accessor for named selection groups.

--- a/tests/test_vis_selections.py
+++ b/tests/test_vis_selections.py
@@ -545,3 +545,34 @@ def test_curve_selections_single_marker(s22, server):
     # Select a single marker
     vis.selections["test_curve"] = [1]
     assert vis.selections["test_curve"] == (1,)
+
+
+# ==================== Selections Repr Tests ====================
+
+
+def test_selections_repr_empty(s22, server):
+    """Test repr for empty selections."""
+    vis = ZnDraw(url=server, room="testroom", user="testuser")
+    assert repr(vis.selections) == "Selections({})"
+    assert str(vis.selections) == "Selections({})"
+
+
+def test_selections_repr_short(s22, server):
+    """Test repr for short selections (≤5 items)."""
+    vis = ZnDraw(url=server, room="testroom", user="testuser")
+    vis.extend(s22)
+
+    vis.selections["particles"] = [0, 1, 2]
+    vis.selections["bonds"] = [3, 4]
+    assert (
+        repr(vis.selections) == "Selections({'bonds': [3, 4], 'particles': [0, 1, 2]})"
+    )
+
+
+def test_selections_repr_long(s22, server):
+    """Test repr for long selections (>5 items)."""
+    vis = ZnDraw(url=server, room="testroom", user="testuser")
+    vis.extend(s22)
+
+    vis.selections["particles"] = [0, 1, 2, 3, 4, 5, 6, 7]
+    assert repr(vis.selections) == "Selections({'particles': [0, 1, 2]... (8 items)})"


### PR DESCRIPTION
Display selections with truncation for large lists (>5 items shows first 3 plus count). Keys are sorted alphabetically for consistent output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)