### PR TITLE
fix README screenshot paths to match auto-generated locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,11 +160,11 @@ zndraw <file> --url https://zndraw.icp.uni-stuttgart.de
 
 ## Self-Hosting
 
-ZnDraw can be deployed using Docker for both development and production environments.
+ZnDraw can be deployed using Docker:
 
 See the [docker/](docker/) directory for complete deployment configurations:
-- [Production deployment](docker/prod/README.md) - Scalable multi-replica setup with nginx
-- [Development setup](docker/dev/README.md) - Hot reload for local development
+- [Standalone](docker/standalone/README.md) - Simple single-instance deployment for personal use or small teams
+- [Production](docker/production/README.md) - Horizontal scaling with nginx load balancer for high load
 
 ## References
 


### PR DESCRIPTION
Update image paths to point to docs/source/_static/screenshots/ where
test_screenshots.py generates them, and fix filenames to match test names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README image references and refreshed screenshots across Overview, API, Geometries, and Analysis.
  * Added new 1D and 2D analysis visuals with light/dark mode variants.
  * Revised deployment wording and quick-links to clarify Docker deployment options (Standalone, Production) and adjusted related wording for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->