### PR TITLE
feat(chat): add SMILES code block support for molecule rendering

### DIFF
--- a/app/src/components/ChatWindow.tsx
+++ b/app/src/components/ChatWindow.tsx
@@ -40,6 +40,7 @@ import { oneDark } from "react-syntax-highlighter/dist/esm/styles/prism";
 import { FrameReference } from "./FrameReference";
 import { useColorScheme, useTheme } from "@mui/material/styles";
 import { LAYOUT_CONSTANTS } from "../constants/layout";
+import { MoleculePreview } from "./shared/MoleculePreview";
 
 import "katex/dist/katex.min.css";
 
@@ -170,6 +171,20 @@ const ProgressRenderer = ({ content }: { content: string }) => {
 					</Typography>
 				</Box>
 			)}
+		</Box>
+	);
+};
+
+const SmilesRenderer = ({ content }: { content: string }) => {
+	const smiles = content.trim();
+
+	if (!smiles) {
+		return null;
+	}
+
+	return (
+		<Box sx={{ my: 1 }}>
+			<MoleculePreview smiles={smiles} size="medium" throttleMs={0} />
 		</Box>
 	);
 };
@@ -537,6 +552,10 @@ const ChatWindow = ({ open, onClose }: ChatWindowProps) => {
 																return <ProgressRenderer content={content} />;
 															}
 
+															if (language === "smiles") {
+																return <SmilesRenderer content={content} />;
+															}
+
 															return match ? (
 																<SyntaxHighlighter
 																	style={
@@ -810,6 +829,10 @@ const ChatWindow = ({ open, onClose }: ChatWindowProps) => {
 
 															if (language === "progress") {
 																return <ProgressRenderer content={content} />;
+															}
+
+															if (language === "smiles") {
+																return <SmilesRenderer content={content} />;
 															}
 
 															return match ? (

--- a/docs/source/python-api.rst
+++ b/docs/source/python-api.rst
@@ -578,6 +578,22 @@ For long-running operations, consider using the :meth:`~zndraw.ZnDraw.progress_t
 context manager instead, which provides real-time updates.
 
 
+Molecule Structures
+^^^^^^^^^^^^^^^^^^^
+
+Display molecule structures in chat using SMILES notation with the ``smiles`` code block syntax:
+
+.. code:: python
+
+    vis.log("""
+    ```smiles
+    CCO
+    ```
+    """)
+
+The SMILES string is rendered as a 2D molecule structure image using RDKit.
+
+
 Property Inspector
 ------------------
 


### PR DESCRIPTION
Add support for ```smiles``` code blocks in chat messages that render 2D molecule structure images using the existing RDKit backend.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for rendering SMILES strings as interactive 2D molecule images in chat. Specify "smiles" as the language in code blocks to display molecular structures.

* **Documentation**
  * Added "Molecule Structures" section with Python code examples demonstrating how to render molecules in chat.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->