### PR TITLE
fix: enable real client IP extraction for load balancing behind rever…

### DIFF
--- a/docker/production/nginx.conf
+++ b/docker/production/nginx.conf
@@ -22,7 +22,16 @@ http {
     gzip_proxied any;
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript image/svg+xml;
 
-    # Upstream with sticky sessions for WebSocket
+    # Extract real client IP from X-Forwarded-For header.
+    # SECURITY: Only safe when behind a trusted reverse proxy (npm, traefik, etc.)
+    # that sets X-Forwarded-For. Do NOT use if nginx is directly exposed to the
+    # internet - attackers could spoof X-Forwarded-For to bypass IP-based controls.
+    set_real_ip_from 0.0.0.0/0;
+    real_ip_header X-Forwarded-For;
+    real_ip_recursive on;
+
+    # Upstream with sticky sessions for WebSocket.
+    # ip_hash uses real client IP for proper load balancing across replicas.
     upstream zndraw {
         ip_hash;
         server zndraw:5000;


### PR DESCRIPTION
…se proxy

When deployed behind another reverse proxy (npm, traefik, etc.), the nginx ip_hash directive was seeing the proxy's IP for all clients, routing all traffic to a single backend replica.

This change configures nginx to extract the real client IP from the X-Forwarded-For header, enabling proper load distribution across all replicas while maintaining sticky sessions per client.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production infrastructure configuration to improve IP address extraction and validation, ensuring accurate client IP identification and enhanced security safeguards for proxy connections.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->