### PR TITLE
refactor: apply React best practices to Canvas and App

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -8,7 +8,14 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ThemeProvider, createTheme } from "@mui/material/styles";
 import CssBaseline from "@mui/material/CssBaseline";
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+	defaultOptions: {
+		queries: {
+			staleTime: 30000, // 30 seconds - matches existing hook usage
+			gcTime: 5 * 60 * 1000, // 5 minutes
+		},
+	},
+});
 
 const theme = createTheme({
 	colorSchemes: {


### PR DESCRIPTION
- Replace 90-line if/else geometry type chain with component maps (PATHTRACING_GEOMETRY_COMPONENTS, SIMPLE_GEOMETRY_COMPONENTS, DATA_ONLY_GEOMETRY_COMPONENTS) for cleaner conditional rendering
- Add QueryClient default options (staleTime: 30s, gcTime: 5min) to centralize React Query configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Refactored geometry component rendering architecture for improved code organization.

* **Performance**
  * Adjusted global query caching behavior with 30-second stale time and 5-minute garbage collection cycle.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->