### PR TITLE
fix: arrays.colors dropdown and startup race condition

### DIFF
--- a/app/src/utils/jsonforms.ts
+++ b/app/src/utils/jsonforms.ts
@@ -109,11 +109,20 @@ export const injectDynamicEnums = (
 			if (
 				obj["x-custom-type"] === "dynamic-enum" &&
 				Array.isArray(obj["x-features"]) &&
-				obj["x-features"].includes("dynamic-atom-props") &&
-				metadata?.keys
+				obj["x-features"].includes("dynamic-atom-props")
 			) {
-				// Inject the keys from the metadata as enum values
-				obj.enum = metadata.keys;
+				// Built-in array references that are always available
+				const features = obj["x-features"] as string[];
+				const hasColorPicker = features.includes("color-picker");
+
+				// Select appropriate array refs based on field type
+				const arrayRefs = hasColorPicker
+					? ["arrays.colors"]
+					: ["arrays.positions", "arrays.radii", "arrays.colors"];
+
+				// Combine with metadata keys (if available), avoiding duplicates
+				const metadataKeys = metadata?.keys || [];
+				obj.enum = [...new Set([...arrayRefs, ...metadataKeys])];
 			}
 
 			// NEW PATTERN: Check for x-features containing "dynamic-geometries"

--- a/src/zndraw/cli.py
+++ b/src/zndraw/cli.py
@@ -559,6 +559,11 @@ def main(
     if browser:
         if first_room:
             browser_url = f"http://localhost:{config.server_port}/rooms/{first_room}"
+            # When loading files, use template=none so browser creates room with 0 frames
+            # This prevents race condition where browser creates "empty" template before
+            # Celery uploads the actual file data
+            if path is not None:
+                browser_url += "?template=none"
         else:
             browser_url = f"http://localhost:{config.server_port}"
         if verbose:


### PR DESCRIPTION
- Add built-in array references (arrays.colors, arrays.positions, arrays.radii) to dynamic enum dropdowns in geometry forms
- Fix race condition when running `zndraw file.h5` by adding ?template=none to browser URL, ensuring room starts with 0 frames until Celery uploads file data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed race condition when loading files from remote/local servers with browser enabled. Prevents premature empty frame creation and ensures proper file data synchronization.

* **Improvements**
  * Enhanced dynamic property enum handling for more reliable operation. Improved automatic detection of color-picker and array-based features.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->