### PR TITLE
fix: disable inherited healthcheck for taskiq worker

### DIFF
--- a/docker/production/docker-compose.yaml
+++ b/docker/production/docker-compose.yaml
@@ -95,10 +95,7 @@ services:
       - ZNDRAW_STORAGE=mongodb://mongo:27017/zndraw
       - ZNDRAW_SERVER_URL=http://caddy
     healthcheck:
-      test: ["CMD-SHELL", "pgrep -f 'taskiq worker'"]
-      interval: 30s
-      timeout: 5s
-      retries: 3
+      test: ["NONE"]
 
   template-loader:
     image: pythonf/zndraw:latest

--- a/docker/standalone/docker-compose.yaml
+++ b/docker/standalone/docker-compose.yaml
@@ -43,10 +43,7 @@ services:
     volumes:
       - zndraw-data:/app/data
     healthcheck:
-      test: ["CMD-SHELL", "pgrep -f 'taskiq worker'"]
-      interval: 30s
-      timeout: 5s
-      retries: 3
+      test: ["NONE"]
 
   template-loader:
     image: pythonf/zndraw:latest


### PR DESCRIPTION
## Summary
- Replace `pgrep`-based healthcheck with `NONE` — the minimal Docker image lacks `procps`
- The worker either runs or the container exits; no degraded state exists, so a healthcheck adds no value

## Test plan
- [ ] `docker compose ps` shows taskiq-worker without "unhealthy" status

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled health verification for the worker service in production and standalone deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->