### PR TITLE
fix: disable submission for global extensions with 0 workers

### DIFF
--- a/frontend/src/components/SecondaryPanel.tsx
+++ b/frontend/src/components/SecondaryPanel.tsx
@@ -197,36 +197,40 @@ const SecondaryPanel = ({ panelTitle }: SecondaryPanelProps) => {
 
 						{selectedJobName && (
 							<>
-								{panelTitle !== "settings" && (() => {
-									const noWorkers =
-										selectedJob != null &&
-										!selectedJob.full_name.startsWith("@internal:") &&
-										selectedJob.workers.length === 0;
-									const tooltipTitle = roomReadOnly
-										? "Room is locked"
-										: noWorkers
-											? "No workers connected"
-											: "";
-									return (
-										<Tooltip title={tooltipTitle}>
-											<span>
-												<Button
-													variant="contained"
-													startIcon={<SaveIcon />}
-													onClick={handleSubmit}
-													disabled={
-														isSubmitting || isLoadingSchema || roomReadOnly || noWorkers
-													}
-													fullWidth
-													color="primary"
-													sx={{ mb: 2 }}
-												>
-													{isSubmitting ? "Running..." : "Run Extension"}
-												</Button>
-											</span>
-										</Tooltip>
-									);
-								})()}
+								{panelTitle !== "settings" &&
+									(() => {
+										const noWorkers =
+											selectedJob != null &&
+											!selectedJob.full_name.startsWith("@internal:") &&
+											selectedJob.workers.length === 0;
+										const tooltipTitle = roomReadOnly
+											? "Room is locked"
+											: noWorkers
+												? "No workers connected"
+												: "";
+										return (
+											<Tooltip title={tooltipTitle}>
+												<span>
+													<Button
+														variant="contained"
+														startIcon={<SaveIcon />}
+														onClick={handleSubmit}
+														disabled={
+															isSubmitting ||
+															isLoadingSchema ||
+															roomReadOnly ||
+															noWorkers
+														}
+														fullWidth
+														color="primary"
+														sx={{ mb: 2 }}
+													>
+														{isSubmitting ? "Running..." : "Run Extension"}
+													</Button>
+												</span>
+											</Tooltip>
+										);
+									})()}
 
 								{isLoadingSchema ? (
 									<FormSkeleton />

--- a/frontend/src/components/SecondaryPanel.tsx
+++ b/frontend/src/components/SecondaryPanel.tsx
@@ -197,25 +197,36 @@ const SecondaryPanel = ({ panelTitle }: SecondaryPanelProps) => {
 
 						{selectedJobName && (
 							<>
-								{panelTitle !== "settings" && (
-									<Tooltip title={roomReadOnly ? "Room is locked" : ""}>
-										<span>
-											<Button
-												variant="contained"
-												startIcon={<SaveIcon />}
-												onClick={handleSubmit}
-												disabled={
-													isSubmitting || isLoadingSchema || roomReadOnly
-												}
-												fullWidth
-												color="primary"
-												sx={{ mb: 2 }}
-											>
-												{isSubmitting ? "Running..." : "Run Extension"}
-											</Button>
-										</span>
-									</Tooltip>
-								)}
+								{panelTitle !== "settings" && (() => {
+									const noWorkers =
+										selectedJob != null &&
+										!selectedJob.full_name.startsWith("@internal:") &&
+										selectedJob.workers.length === 0;
+									const tooltipTitle = roomReadOnly
+										? "Room is locked"
+										: noWorkers
+											? "No workers connected"
+											: "";
+									return (
+										<Tooltip title={tooltipTitle}>
+											<span>
+												<Button
+													variant="contained"
+													startIcon={<SaveIcon />}
+													onClick={handleSubmit}
+													disabled={
+														isSubmitting || isLoadingSchema || roomReadOnly || noWorkers
+													}
+													fullWidth
+													color="primary"
+													sx={{ mb: 2 }}
+												>
+													{isSubmitting ? "Running..." : "Run Extension"}
+												</Button>
+											</span>
+										</Tooltip>
+									);
+								})()}
 
 								{isLoadingSchema ? (
 									<FormSkeleton />

--- a/src/zndraw_joblib/exceptions.py
+++ b/src/zndraw_joblib/exceptions.py
@@ -169,6 +169,13 @@ class InternalJobNotConfigured(ProblemType):
     status: ClassVar[int] = 503
 
 
+class NoWorkersAvailable(ProblemType):
+    """Job has no connected workers to process the task."""
+
+    title: ClassVar[str] = "Conflict"
+    status: ClassVar[int] = 409
+
+
 class ProviderNotFound(ProblemType):
     """The requested provider does not exist."""
 

--- a/src/zndraw_joblib/router.py
+++ b/src/zndraw_joblib/router.py
@@ -48,6 +48,7 @@ from zndraw_joblib.exceptions import (
     InvalidCategory,
     InvalidTaskTransition,
     JobNotFound,
+    NoWorkersAvailable,
     ProviderNotFound,
     ProviderTimeout,
     SchemaConflict,
@@ -605,6 +606,18 @@ async def submit_task(
                 " but no executor is available"
             )
         )
+
+    # Reject submission for non-@internal jobs with no connected workers
+    if job.room_id != "@internal":
+        worker_count = (
+            await session.execute(
+                select(func.count()).where(WorkerJobLink.job_id == job.id)
+            )
+        ).scalar_one()
+        if worker_count == 0:
+            raise NoWorkersAvailable.exception(
+                detail=f"Job '{job.full_name}' has no connected workers"
+            )
 
     # Create task
     task = Task(

--- a/tests/zndraw_joblib/test_router_task_submit.py
+++ b/tests/zndraw_joblib/test_router_task_submit.py
@@ -153,3 +153,28 @@ def test_submit_task_empty_payload(seeded_client):
     assert response.status_code == 202
     data = TaskResponse.model_validate(response.json())
     assert data.payload == {}
+
+
+def test_submit_global_task_no_workers_returns_409(seeded_client):
+    """Submitting to a global job with 0 workers returns 409."""
+    worker_id = seeded_client.seeded_worker_id
+
+    # Create a pending task so the job survives orphan cleanup
+    resp = seeded_client.post(
+        "/v1/joblib/rooms/room_1/tasks/@global:modifiers:Rotate",
+        json={"payload": {}},
+    )
+    assert resp.status_code == 202
+
+    # Delete the worker — job stays because it has a pending task
+    resp = seeded_client.delete(f"/v1/joblib/workers/{worker_id}")
+    assert resp.status_code == 204
+
+    # Now submit again — should be rejected (0 workers)
+    resp = seeded_client.post(
+        "/v1/joblib/rooms/room_1/tasks/@global:modifiers:Rotate",
+        json={"payload": {}},
+    )
+    assert resp.status_code == 409
+    error = ProblemDetail.model_validate(resp.json())
+    assert "no connected workers" in error.detail


### PR DESCRIPTION
## Summary

Closes #907

- **Backend**: `submit_task()` now rejects submissions for non-`@internal` jobs that have 0 connected workers (returns 409 with RFC 9457 problem detail)
- **Frontend**: "Run Extension" button is disabled with a "No workers connected" tooltip when `workerCount === 0` for non-internal jobs
- **Test**: `test_submit_global_task_no_workers_returns_409` verifies the backend guard

## Test plan

- [x] All 305 joblib tests pass
- [x] TypeScript compiles cleanly
- [ ] Manual: register a global extension, disconnect worker, verify submit button is disabled
- [ ] Manual: verify tooltip shows "No workers connected"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added validation to prevent task submission when no workers are connected to a job, returning a clear error message.
  * Enhanced button feedback with tooltips that indicate when no workers are available for the selected job.

* **Tests**
  * Added test coverage for task submission when workers are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->