### PR TITLE
fix: migrate to SQLModel session.exec() and gate regressions (#890)

### DIFF
--- a/docs/superpowers/plans/2026-04-08-sqlmodel-session-exec-migration.md
+++ b/docs/superpowers/plans/2026-04-08-sqlmodel-session-exec-migration.md
@@ -1,0 +1,1907 @@
+# SQLModel session.exec() Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate 15,000+ SQLModel `DeprecationWarning` instances from CI by migrating all 77 `session.execute()` call sites in `src/` to `session.exec()`, and add a pytest warning filter that prevents regressions.
+
+**Architecture:** Mechanical, deterministic rewrite across 17 files. Each file becomes an independent atomic commit so bisection is trivial if a regression slips through. A single final commit adds a `pyproject.toml` `filterwarnings` entry that escalates any future reintroduction of the deprecated API to a hard test failure. No behavioral changes, no new code, no new tests.
+
+**Tech Stack:** Python 3.11, SQLModel 0.0.24+, SQLAlchemy 2.x async, pytest, uv.
+
+**Related spec:** `docs/superpowers/specs/2026-04-08-sqlmodel-session-exec-migration-design.md`
+**Related issue:** [zincware/ZnDraw#890](https://github.com/zincware/ZnDraw/issues/890)
+**Worktree:** `/Users/fzills/tools/zndraw-fastapi/.claude/worktrees/fix+sqlmodel-session-exec-migration`
+
+---
+
+## Rewrite rules (apply to every task)
+
+These rules are derived from SQLModel's `AsyncSession.exec()` overloads in `.venv/lib/python3.11/site-packages/sqlmodel/ext/asyncio/session.py` (verified directly). They are the SOTA recommendation per sqlmodel.tiangolo.com.
+
+### Rule 1 — Imports
+
+Swap `select` to the SQLModel re-export. Keep `func`, `and_`, `or_`, `update`, `delete`, `text`, `selectinload`, etc. from sqlalchemy — SQLModel doesn't re-export all of them, and they interop transparently.
+
+```python
+# Before
+from sqlalchemy import func, select, update
+
+# After
+from sqlalchemy import func, update
+from sqlmodel import select
+```
+
+If a file already imports `select` from `sqlmodel`, do nothing to imports.
+
+### Rule 2 — SELECT-one returning a model instance
+
+| Before | After |
+|---|---|
+| `result = await session.execute(select(Model).where(...))`<br>`obj = result.scalar_one_or_none()` | `result = await session.exec(select(Model).where(...))`<br>`obj = result.one_or_none()` |
+| `result = await session.execute(select(Model).where(...))`<br>`obj = result.scalar_one()` | `result = await session.exec(select(Model).where(...))`<br>`obj = result.one()` |
+
+One-liner variants:
+
+| Before | After |
+|---|---|
+| `obj = (await session.execute(stmt)).scalar_one_or_none()` | `obj = (await session.exec(stmt)).one_or_none()` |
+| `obj = (await session.execute(stmt)).scalar_one()` | `obj = (await session.exec(stmt)).one()` |
+
+### Rule 3 — SELECT-many returning model instances
+
+| Before | After |
+|---|---|
+| `result = await session.execute(select(Model).where(...))`<br>`rows = result.scalars().all()` | `result = await session.exec(select(Model).where(...))`<br>`rows = result.all()` |
+| `rows = (await session.execute(stmt)).scalars().all()` | `rows = (await session.exec(stmt)).all()` |
+| `rows = list(result.scalars().all())` | `rows = list(result.all())` |
+
+### Rule 4 — Iteration over scalars
+
+| Before | After |
+|---|---|
+| `for row in result.scalars().all(): ...` | `for row in result.all(): ...` |
+| `for row in result.scalars(): ...` | `for row in result: ...` |
+
+### Rule 5 — SELECT aggregates (`func.count()`)
+
+```python
+# Before
+total_result = await session.execute(select(func.count()).select_from(X))
+total = total_result.scalar()
+
+# After
+total_result = await session.exec(select(func.count()).select_from(X))
+total = total_result.one()
+```
+
+`.one()` on an aggregate result returns the scalar int directly.
+
+### Rule 6 — Bulk `update()` / `delete()`
+
+Per SQLModel source, `AsyncSession.exec()` has an `UpdateBase` overload returning `CursorResult[Any]` — bulk updates/deletes are fully typed. No type-ignore needed.
+
+```python
+# Before
+stmt = update(Task).where(...).values(...)
+cursor_result = await session.execute(stmt)
+if cursor_result.rowcount == 1:
+    ...
+
+# After
+stmt = update(Task).where(...).values(...)
+cursor_result = await session.exec(stmt)
+if cursor_result.rowcount == 1:
+    ...
+```
+
+### Rule 7 — Multi-column SELECT (tuple result)
+
+`select(Model.col1, Model.col2)` returns a `TupleResult` from `session.exec()`. Rows are tuple-like with attribute access by column key — the consuming code rarely needs to change.
+
+```python
+# Before
+result = await session.execute(select(Job.id, Job.room_id).where(...))
+job_rooms = {row.id: row.room_id for row in result.all()}
+
+# After
+result = await session.exec(select(Job.id, Job.room_id).where(...))
+job_rooms = {row.id: row.room_id for row in result.all()}
+```
+
+Note: do **not** call `.scalars()` on a multi-column select — it would drop all columns but the first.
+
+---
+
+## Special notes
+
+- **sqlmodel re-exports `func`** (`from sqlmodel import func, select` works), but most files in this codebase import `func` from sqlalchemy. Keep the existing style — don't churn imports beyond the `select` swap.
+- **`src/zndraw/routes/frames.py`** uses `from sqlalchemy import select as sa_select` and references `sa_select(...)` at line 88. There is only one call site in the file. Replace the alias with a normal `from sqlmodel import select` and drop the `sa_` prefix.
+- **`src/zndraw_joblib/registry.py`** has a **local** `from sqlalchemy import select` inside a function (line 98), not a module-level import. Change the local import to `from sqlmodel import select`.
+- **`src/zndraw/routes/selection_groups.py`** similarly has a local `from sqlmodel import select` inside a function (line 48). It already imports from sqlmodel — only the `session.execute` → `session.exec` + `.scalars()` swap is needed.
+- **`src/zndraw/routes/rooms.py`** uses a pattern where `for row in result.scalars().all(): ...` appears four times (lines 205, 223, 236, 250). Apply Rule 4.
+- **`src/zndraw_joblib/router.py:730`** is the one bulk `update()` call site in the entire `src/` tree. Rule 6 applies.
+- **`src/zndraw_joblib/sweeper.py:127-130`** is the one multi-column select. Rule 7 applies — the consuming dict comprehension stays identical.
+
+---
+
+## File structure
+
+| File | Sites | Rules invoked | Notes |
+|---|---|---|---|
+| `src/zndraw_joblib/registry.py` | 1 | R1 (local), R2 | Local import inside function |
+| `src/zndraw_joblib/dependencies.py` | 1 | R2 | Already imports sqlmodel select |
+| `src/zndraw_joblib/sweeper.py` | 9 | R1, R2, R3, R4, R7 | Multi-column select at L127-130 |
+| `src/zndraw_joblib/router.py` | 40 | R1, R2, R3, R5, R6 | The big file, incl. bulk update |
+| `src/zndraw/database.py` | 1 | R2 | Already imports sqlmodel select |
+| `src/zndraw/routes/admin.py` | 2 | R2, R3, R5 | Already imports sqlmodel select+func |
+| `src/zndraw/routes/rooms.py` | 5 | R3, R4 | 4× iteration pattern |
+| `src/zndraw/routes/presets.py` | 4 | R3 | One-liner patterns |
+| `src/zndraw/routes/chat.py` | 3 | R3, R5 | Mixed select + count |
+| `src/zndraw/routes/screenshots.py` | 2 | R3, R5 | One-liner count + select |
+| `src/zndraw/routes/geometries.py` | 1 | R3 | |
+| `src/zndraw/routes/figures.py` | 1 | R3 | |
+| `src/zndraw/routes/selection_groups.py` | 1 | R4 | Local sqlmodel select already |
+| `src/zndraw/routes/bookmarks.py` | 1 | R3 | |
+| `src/zndraw/routes/frames.py` | 1 | R1, R2 | Drop `sa_select` alias |
+| `src/zndraw_auth/db.py` | 1 | R1, R2 | |
+| `src/zndraw_auth/cli_login.py` | 3 | R1, R2 | All R2 pattern |
+
+**Total: 77 sites across 17 files.**
+
+Final change: `pyproject.toml` — add `filterwarnings` entry under `[tool.pytest.ini_options]`.
+
+---
+
+## Task list
+
+### Task 1: Baseline verification
+
+**Purpose:** Confirm the working tree matches the spec's assumptions before migrating anything. Establishes green baseline for bisection.
+
+**Files:**
+- Read: `pyproject.toml` (verify no existing `filterwarnings`)
+- Read: `src/zndraw/socketio.py:200` (existing `session.exec()` reference — sanity check)
+
+- [ ] **Step 1: Verify worktree and branch**
+
+Run:
+```bash
+pwd
+git status --short
+git branch --show-current
+```
+
+Expected: pwd ends in `.claude/worktrees/fix+sqlmodel-session-exec-migration`, branch is `worktree-fix+sqlmodel-session-exec-migration`, working tree clean.
+
+- [ ] **Step 2: Confirm call site count matches the spec**
+
+Run:
+```bash
+grep -rc "session\.execute(" src/ | grep -v ":0$" | sort
+```
+
+Expected output (17 files, summing to 77):
+```
+src/zndraw/database.py:1
+src/zndraw/routes/admin.py:2
+src/zndraw/routes/bookmarks.py:1
+src/zndraw/routes/chat.py:3
+src/zndraw/routes/figures.py:1
+src/zndraw/routes/frames.py:1
+src/zndraw/routes/geometries.py:1
+src/zndraw/routes/presets.py:4
+src/zndraw/routes/rooms.py:5
+src/zndraw/routes/screenshots.py:2
+src/zndraw/routes/selection_groups.py:1
+src/zndraw_auth/cli_login.py:3
+src/zndraw_auth/db.py:1
+src/zndraw_joblib/dependencies.py:1
+src/zndraw_joblib/registry.py:1
+src/zndraw_joblib/router.py:40
+src/zndraw_joblib/sweeper.py:9
+```
+
+If any count differs, stop and reconcile against the spec before proceeding.
+
+- [ ] **Step 3: Run the full existing test suite as a green baseline**
+
+Run:
+```bash
+uv sync
+uv run --active pytest tests/ -q 2>&1 | tail -20
+```
+
+Expected: all tests pass. Note the "X passed" and "Y warnings" counts for later comparison.
+
+If tests are failing on `main`, stop — the migration's verification step won't distinguish new failures from pre-existing ones.
+
+---
+
+### Task 2: Migrate `src/zndraw_joblib/registry.py` (1 site — worked example)
+
+**Files:**
+- Modify: `src/zndraw_joblib/registry.py:98,108,115`
+
+This is the canonical single-site migration. Use it as a template for understanding the other tasks.
+
+- [ ] **Step 1: Read the current state of the function**
+
+Read lines 95-125 of `src/zndraw_joblib/registry.py`. The import is local inside `register_internal_jobs()` at line 98. The `session.execute()` call is at line 108 with `scalar_one_or_none()` at line 115.
+
+- [ ] **Step 2: Swap the local import**
+
+Change line 98:
+
+```python
+# Before
+    from sqlalchemy import select
+
+# After
+    from sqlmodel import select
+```
+
+- [ ] **Step 3: Swap `session.execute` → `session.exec` and `scalar_one_or_none` → `one_or_none`**
+
+Change line 108 and line 115:
+
+```python
+# Before
+            result = await session.execute(
+                select(Job).where(
+                    Job.room_id == "@internal",
+                    Job.category == category,
+                    Job.name == name,
+                )
+            )
+            existing = result.scalar_one_or_none()
+
+# After
+            result = await session.exec(
+                select(Job).where(
+                    Job.room_id == "@internal",
+                    Job.category == category,
+                    Job.name == name,
+                )
+            )
+            existing = result.one_or_none()
+```
+
+- [ ] **Step 4: Verify no `session.execute` or `scalar_one_or_none` remains in the file**
+
+Run:
+```bash
+grep -n "session\.execute\|scalar_one_or_none\|scalar_one\b\|\.scalars(" src/zndraw_joblib/registry.py
+```
+
+Expected: no output.
+
+- [ ] **Step 5: Run the test that covers registry.py**
+
+Run:
+```bash
+uv run --active pytest tests/zndraw_joblib/test_registry.py -q
+```
+
+Expected: `8 passed`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/zndraw_joblib/registry.py
+git commit -m "$(cat <<'EOF'
+refactor(joblib): migrate registry.py to session.exec() (#890)
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: Migrate `src/zndraw_joblib/dependencies.py` (1 site)
+
+**Files:**
+- Modify: `src/zndraw_joblib/dependencies.py:153,156`
+
+Module already imports `from sqlmodel import select` (line 8) — no import change.
+
+- [ ] **Step 1: Read lines 150-165 of `src/zndraw_joblib/dependencies.py`**
+
+Confirm: line 153 calls `session.execute(...)`, line 156 calls `result.scalar_one_or_none()`.
+
+- [ ] **Step 2: Rewrite the call**
+
+```python
+# Before (lines 153-156)
+    result = await session.execute(
+        select(User).where(User.email == settings.internal_worker_email)  # type: ignore[arg-type]
+    )
+    user = result.scalar_one_or_none()
+
+# After
+    result = await session.exec(
+        select(User).where(User.email == settings.internal_worker_email)  # type: ignore[arg-type]
+    )
+    user = result.one_or_none()
+```
+
+- [ ] **Step 3: Verify the file is clean**
+
+Run:
+```bash
+grep -n "session\.execute\|scalar_one_or_none\|scalar_one\b\|\.scalars(" src/zndraw_joblib/dependencies.py
+```
+
+Expected: no output.
+
+- [ ] **Step 4: Run relevant tests**
+
+Run:
+```bash
+uv run --active pytest tests/zndraw_joblib/ -q -x
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/zndraw_joblib/dependencies.py
+git commit -m "$(cat <<'EOF'
+refactor(joblib): migrate dependencies.py to session.exec() (#890)
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: Migrate `src/zndraw_joblib/sweeper.py` (9 sites)
+
+**Files:**
+- Modify: `src/zndraw_joblib/sweeper.py` — line 11 (import), and all 9 call sites.
+
+Call sites map (from `grep -n "session\.execute"`):
+
+| Line | Pattern | Rule |
+|---|---|---|
+| 49 | `session.execute(select(Job).where(Job.id == job_id))` → `.scalar_one_or_none()` | R2 |
+| 55 | `session.execute(select(WorkerJobLink)...limit(1))` → `if result.scalar_one_or_none()` | R2 |
+| 62 | `session.execute(select(Task)...limit(1))` → `if result.scalar_one_or_none()` | R2 |
+| 100 | `session.execute(select(Task).options(selectinload)...)` → `.scalars().all()` | R3 |
+| 119 | `session.execute(select(WorkerJobLink).where(...))` → `.scalars().all()` | R3 |
+| 127 | `session.execute(select(Job.id, Job.room_id).where(...))` → `result.all()` for tuple rows | R7 |
+| 139 | `session.execute(select(ProviderRecord).where(...))` → `.scalars().all()` | R3 |
+| 191 | `session.execute(select(Worker).where(...))` → `.scalars().all()` | R3 |
+| 229 | `session.execute(select(Task).join(Job)...)` → `.scalars().all()` | R3 |
+
+- [ ] **Step 1: Swap the import**
+
+Change line 11:
+
+```python
+# Before
+from sqlalchemy import func as sa_func, select
+
+# After
+from sqlalchemy import func as sa_func
+from sqlmodel import select
+```
+
+Keep `sa_func` as-is — it's used at line 236 and renaming would churn an unrelated line.
+
+- [ ] **Step 2: Rewrite line 49**
+
+```python
+# Before
+    result = await session.execute(select(Job).where(Job.id == job_id))
+    job = result.scalar_one_or_none()
+
+# After
+    result = await session.exec(select(Job).where(Job.id == job_id))
+    job = result.one_or_none()
+```
+
+- [ ] **Step 3: Rewrite lines 55-58**
+
+```python
+# Before
+    result = await session.execute(
+        select(WorkerJobLink).where(WorkerJobLink.job_id == job_id).limit(1)
+    )
+    if result.scalar_one_or_none():
+
+# After
+    result = await session.exec(
+        select(WorkerJobLink).where(WorkerJobLink.job_id == job_id).limit(1)
+    )
+    if result.one_or_none():
+```
+
+- [ ] **Step 4: Rewrite lines 62-70**
+
+```python
+# Before
+    result = await session.execute(
+        select(Task)
+        .where(
+            Task.job_id == job_id,
+            Task.status == TaskStatus.PENDING,
+        )
+        .limit(1)
+    )
+    if result.scalar_one_or_none():
+
+# After
+    result = await session.exec(
+        select(Task)
+        .where(
+            Task.job_id == job_id,
+            Task.status == TaskStatus.PENDING,
+        )
+        .limit(1)
+    )
+    if result.one_or_none():
+```
+
+- [ ] **Step 5: Rewrite lines 100-108**
+
+```python
+# Before
+    result = await session.execute(
+        select(Task)
+        .options(selectinload(Task.job))
+        .where(
+            Task.worker_id == worker.id,
+            Task.status.in_({TaskStatus.CLAIMED, TaskStatus.RUNNING}),
+        )
+    )
+    worker_tasks = result.scalars().all()
+
+# After
+    result = await session.exec(
+        select(Task)
+        .options(selectinload(Task.job))
+        .where(
+            Task.worker_id == worker.id,
+            Task.status.in_({TaskStatus.CLAIMED, TaskStatus.RUNNING}),
+        )
+    )
+    worker_tasks = result.all()
+```
+
+- [ ] **Step 6: Rewrite lines 119-122**
+
+```python
+# Before
+    result = await session.execute(
+        select(WorkerJobLink).where(WorkerJobLink.worker_id == worker.id)
+    )
+    links = result.scalars().all()
+
+# After
+    result = await session.exec(
+        select(WorkerJobLink).where(WorkerJobLink.worker_id == worker.id)
+    )
+    links = result.all()
+```
+
+- [ ] **Step 7: Rewrite lines 127-130 (multi-column select — Rule 7)**
+
+Only `execute` → `exec` changes. The dict comprehension stays identical — tuple rows keep attribute access.
+
+```python
+# Before
+        result = await session.execute(
+            select(Job.id, Job.room_id).where(Job.id.in_(job_ids))
+        )
+        job_rooms = {row.id: row.room_id for row in result.all()}
+
+# After
+        result = await session.exec(
+            select(Job.id, Job.room_id).where(Job.id.in_(job_ids))
+        )
+        job_rooms = {row.id: row.room_id for row in result.all()}
+```
+
+- [ ] **Step 8: Rewrite lines 139-142**
+
+```python
+# Before
+    result = await session.execute(
+        select(ProviderRecord).where(ProviderRecord.worker_id == worker.id)
+    )
+    providers = result.scalars().all()
+
+# After
+    result = await session.exec(
+        select(ProviderRecord).where(ProviderRecord.worker_id == worker.id)
+    )
+    providers = result.all()
+```
+
+- [ ] **Step 9: Rewrite lines 191-192**
+
+```python
+# Before
+    result = await session.execute(select(Worker).where(Worker.last_heartbeat < cutoff))
+    stale_workers = result.scalars().all()
+
+# After
+    result = await session.exec(select(Worker).where(Worker.last_heartbeat < cutoff))
+    stale_workers = result.all()
+```
+
+- [ ] **Step 10: Rewrite lines 229-239**
+
+```python
+# Before
+    result = await session.execute(
+        select(Task)
+        .join(Job)
+        .options(selectinload(Task.job))
+        .where(
+            Job.room_id == "@internal",
+            Task.status.in_({TaskStatus.RUNNING, TaskStatus.CLAIMED}),
+            sa_func.coalesce(Task.started_at, Task.created_at) < cutoff,
+        )
+    )
+    stuck_tasks = result.scalars().all()
+
+# After
+    result = await session.exec(
+        select(Task)
+        .join(Job)
+        .options(selectinload(Task.job))
+        .where(
+            Job.room_id == "@internal",
+            Task.status.in_({TaskStatus.RUNNING, TaskStatus.CLAIMED}),
+            sa_func.coalesce(Task.started_at, Task.created_at) < cutoff,
+        )
+    )
+    stuck_tasks = result.all()
+```
+
+- [ ] **Step 11: Verify the file is clean**
+
+Run:
+```bash
+grep -n "session\.execute\|scalar_one_or_none\|scalar_one\b\|\.scalars(" src/zndraw_joblib/sweeper.py
+```
+
+Expected: no output.
+
+- [ ] **Step 12: Run sweeper tests**
+
+Run:
+```bash
+uv run --active pytest tests/zndraw_joblib/test_sweeper.py -q
+```
+
+Expected: `16 passed`.
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add src/zndraw_joblib/sweeper.py
+git commit -m "$(cat <<'EOF'
+refactor(joblib): migrate sweeper.py to session.exec() (#890)
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5: Migrate `src/zndraw_joblib/router.py` (40 sites)
+
+**Files:**
+- Modify: `src/zndraw_joblib/router.py` — line 11 (import), plus 40 call sites across ~25 functions.
+
+This is the largest file. Call sites are grouped by function. Apply the rules rule-by-rule; most sites are Rule 2 or Rule 3 mechanical rewrites. **One bulk update site at line 733 uses Rule 6. Four count aggregates use Rule 5.**
+
+Full call site map (from `grep -n`):
+
+| Line | Function | Rule | Pattern |
+|---|---|---|---|
+| 137 | `_resolve_job` | R2 | `.scalar_one_or_none()` |
+| 151 | `_task_response` | R2 | `.scalar_one_or_none()` |
+| 184 | `_bulk_queue_positions` | R3 | `.scalars().all()` (iterated) |
+| 223 | `_task_status_emission` | R2 | `.scalar_one_or_none()` |
+| 294 | `register_job` | R2 | `.scalar_one_or_none()` |
+| 331 | `register_job` | R2 | `.scalar_one_or_none()` |
+| 349 | `register_job` | R2 | `.scalar_one_or_none()` |
+| 365 | `register_job` | R3 | `.scalars().all()` |
+| 396 | `list_jobs` | R5 | `select(...).scalar()` count |
+| 402 | `list_jobs` | R3 | `.scalars().all()` |
+| 432 | `list_workers_for_room` | R3 | `.scalars().all()` |
+| 448 | `list_workers_for_room` | R5 | count |
+| 454 | `list_workers_for_room` | R3 | `.scalars().all()` |
+| 494 | `list_tasks_for_room` | R5 | count |
+| 500 | `list_tasks_for_room` | R3 | `.scalars().all()` |
+| 534 | `list_tasks_for_job` | R5 | count |
+| 540 | `list_tasks_for_job` | R3 | `.scalars().all()` |
+| 563 | `get_job` | R3 | `.scalars().all()` |
+| 613 | `submit_task` | R5 | one-liner `.scalar_one()` count |
+| 687 | `claim_task` | R2 | `.scalar_one_or_none()` |
+| 697 | `claim_task` | R3 | `.scalars().all()` |
+| 714 | `claim_task` | R2 | `.scalar_one_or_none()` (inside retry loop) |
+| **733** | `claim_task` | **R6** | **bulk `update(Task)` — keep `.rowcount`** |
+| 765 | `claim_task` | R2 | `.scalar_one()` |
+| 784 | `get_task_status` | R2 | `.scalar_one_or_none()` |
+| 805 | `get_task_status` | R2 | `.scalar_one_or_none()` (inside poll loop) |
+| 814 | `get_task_status` | R2 | `.scalar_one()` |
+| 828 | `update_task_status` | R2 | `.scalar_one_or_none()` |
+| 837 | `update_task_status` | R2 | `.scalar_one_or_none()` |
+| 891 | `list_workers` | R5 | one-liner-ish count |
+| 895 | `list_workers` | R3 | `.scalars().all()` |
+| 922 | `worker_heartbeat` | R2 | `.scalar_one_or_none()` |
+| 950 | `delete_worker` | R2 | `.scalar_one_or_none()` |
+| 997 | `_resolve_provider` | R2 | `.scalar_one_or_none()` |
+| 1043 | `register_provider` | R2 | `.scalar_one_or_none()` |
+| 1060 | `register_provider` | R2 | `.scalar_one_or_none()` |
+| 1114 | `list_providers` | R5 | count |
+| 1119 | `list_providers` | R3 | `.scalars().all()` |
+| 1226 | `delete_provider` | R2 | `.scalar_one_or_none()` |
+| 1258 | `upload_provider_result` | R2 | `.scalar_one_or_none()` |
+
+- [ ] **Step 1: Swap the import**
+
+Change line 11:
+
+```python
+# Before
+from sqlalchemy import func, select, update
+
+# After
+from sqlalchemy import func, update
+from sqlmodel import select
+```
+
+- [ ] **Step 2: Apply Rule 2 rewrites (SELECT-one)**
+
+For each of these sites, change `session.execute` → `session.exec` and the result accessor as shown. Use `Edit` with enough context to make each change unique.
+
+Lines 137 + 144, 151 + 152, 223 + 224, 294 + 301, 331 + 337, 349 + 355, 687 + 688, 714 + 722, 765 + 766, 784 + 785, 805 + 806, 814 + 815, 828 + 829, 837 + 840, 922 + 923, 950 + 951, 997 + 1004, 1043 + 1049, 1060 + 1067, 1226 + 1229, 1258 + 1261:
+
+Rewrite each:
+- `await session.execute(` → `await session.exec(`
+- `result.scalar_one_or_none()` → `result.one_or_none()`
+- `result.scalar_one()` → `result.one()` (at lines 766 and 815)
+
+- [ ] **Step 3: Apply Rule 3 rewrites (SELECT-many)**
+
+Lines 184, 365, 402, 432, 454, 500, 540, 563, 697, 895, 1119:
+
+Rewrite each:
+- `await session.execute(` → `await session.exec(`
+- `result.scalars().all()` → `result.all()`
+
+- [ ] **Step 4: Apply Rule 5 rewrites (aggregates/count)**
+
+Lines 396 + 399, 448 + 451, 494 + 497, 534 + 537, 891 + 892, 1114 + 1117:
+
+Rewrite each:
+- `total_result = await session.execute(` → `total_result = await session.exec(`
+- `total = total_result.scalar()` → `total = total_result.one()`
+
+Line 613-616 is a one-liner count in `submit_task`:
+
+```python
+# Before
+        worker_count = (
+            await session.execute(
+                select(func.count()).where(WorkerJobLink.job_id == job.id)
+            )
+        ).scalar_one()
+
+# After
+        worker_count = (
+            await session.exec(
+                select(func.count()).where(WorkerJobLink.job_id == job.id)
+            )
+        ).one()
+```
+
+Line 891 is also one-liner style:
+
+```python
+# Before
+    total_result = await session.execute(select(func.count()).select_from(Worker))
+    total = total_result.scalar()
+
+# After
+    total_result = await session.exec(select(func.count()).select_from(Worker))
+    total = total_result.one()
+```
+
+- [ ] **Step 5: Apply Rule 6 rewrite (bulk UPDATE at line 733)**
+
+This is the optimistic-locking task-claim path. The `CursorResult.rowcount` semantics must be preserved.
+
+```python
+# Before (lines 727-737)
+            # Atomically update only if still PENDING (optimistic locking)
+            stmt = (
+                update(Task)
+                .where(Task.id == task_id, Task.status == TaskStatus.PENDING)
+                .values(status=TaskStatus.CLAIMED, worker_id=request.worker_id)
+            )
+            cursor_result = await session.execute(stmt)
+            await session.commit()
+
+            # Check if we actually claimed it (rowcount == 1 means success)
+            if cursor_result.rowcount == 1:
+
+# After
+            # Atomically update only if still PENDING (optimistic locking)
+            stmt = (
+                update(Task)
+                .where(Task.id == task_id, Task.status == TaskStatus.PENDING)
+                .values(status=TaskStatus.CLAIMED, worker_id=request.worker_id)
+            )
+            cursor_result = await session.exec(stmt)
+            await session.commit()
+
+            # Check if we actually claimed it (rowcount == 1 means success)
+            if cursor_result.rowcount == 1:
+```
+
+SQLModel's `exec()` has an `UpdateBase` overload returning `CursorResult[Any]`, so `.rowcount` is fully typed. No ignore comment needed.
+
+- [ ] **Step 6: Verify the file is clean**
+
+Run:
+```bash
+grep -n "session\.execute\|scalar_one_or_none\|scalar_one\b\|\.scalars(" src/zndraw_joblib/router.py
+```
+
+Expected: no output.
+
+- [ ] **Step 7: Run the full joblib test suite**
+
+Run:
+```bash
+uv run --active pytest tests/zndraw_joblib/ -q
+```
+
+Expected: all tests pass. Pay special attention to `test_resilience.py` which exercises the claim-task / optimistic-locking path.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/zndraw_joblib/router.py
+git commit -m "$(cat <<'EOF'
+refactor(joblib): migrate router.py to session.exec() (#890)
+
+40 sites across ~25 endpoints, including the bulk update() in the
+optimistic-locking claim_task path (uses the UpdateBase overload on
+AsyncSession.exec for fully typed CursorResult.rowcount).
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 6: Migrate `src/zndraw/database.py` (1 site)
+
+**Files:**
+- Modify: `src/zndraw/database.py:113,116`
+
+Module already imports `select` from sqlmodel (line 24) — no import change.
+
+- [ ] **Step 1: Read lines 108-125 of `src/zndraw/database.py`**
+
+- [ ] **Step 2: Rewrite the call**
+
+```python
+# Before (lines 113-116)
+    result = await session.execute(
+        select(User).where(User.email == internal_worker_email)
+    )
+    existing = result.scalar_one_or_none()
+
+# After
+    result = await session.exec(
+        select(User).where(User.email == internal_worker_email)
+    )
+    existing = result.one_or_none()
+```
+
+Note: the exact `.where(...)` expression may differ — read the file and preserve it verbatim. Only change `execute` → `exec` and `scalar_one_or_none` → `one_or_none`.
+
+- [ ] **Step 3: Verify**
+
+Run:
+```bash
+grep -n "session\.execute\|scalar_one_or_none\|scalar_one\b\|\.scalars(" src/zndraw/database.py
+```
+
+Expected: no output.
+
+- [ ] **Step 4: Run tests**
+
+Run:
+```bash
+uv run --active pytest tests/zndraw/ -q -x -k "database or room"
+```
+
+Expected: tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/zndraw/database.py
+git commit -m "$(cat <<'EOF'
+refactor(zndraw): migrate database.py to session.exec() (#890)
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 7: Migrate `src/zndraw/routes/admin.py` (2 sites)
+
+**Files:**
+- Modify: `src/zndraw/routes/admin.py:75,76,79,80`
+
+Module already imports `from sqlmodel import func, select` (line 14) — no import change.
+
+- [ ] **Step 1: Rewrite lines 75-80**
+
+```python
+# Before
+    count_result = await session.execute(select(func.count()).select_from(User))
+    total = count_result.scalar_one()
+
+    # Get paginated users
+    result = await session.execute(select(User).offset(offset).limit(limit))
+    users = list(result.scalars().all())
+
+# After
+    count_result = await session.exec(select(func.count()).select_from(User))
+    total = count_result.one()
+
+    # Get paginated users
+    result = await session.exec(select(User).offset(offset).limit(limit))
+    users = list(result.all())
+```
+
+- [ ] **Step 2: Verify**
+
+Run:
+```bash
+grep -n "session\.execute\|scalar_one_or_none\|scalar_one\b\|\.scalars(" src/zndraw/routes/admin.py
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Run tests**
+
+Run:
+```bash
+uv run --active pytest tests/zndraw/test_admin.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/zndraw/routes/admin.py
+git commit -m "$(cat <<'EOF'
+refactor(zndraw): migrate routes/admin.py to session.exec() (#890)
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 8: Migrate `src/zndraw/routes/rooms.py` (5 sites)
+
+**Files:**
+- Modify: `src/zndraw/routes/rooms.py:202-205, 220-223, 233-236, 247-250, 420-421`
+
+Module already imports `from sqlmodel import select` (line 14) — no import change.
+
+All four sites at 202-250 use the same iterate-over-scalars pattern (Rule 3 + Rule 4 combined). Site at 420 uses a list-wrap pattern.
+
+- [ ] **Step 1: Rewrite lines 202-205**
+
+```python
+# Before
+    result = await session.execute(
+        select(RoomGeometry).where(RoomGeometry.room_id == source_room_id)
+    )
+    for row in result.scalars().all():
+
+# After
+    result = await session.exec(
+        select(RoomGeometry).where(RoomGeometry.room_id == source_room_id)
+    )
+    for row in result.all():
+```
+
+- [ ] **Step 2: Rewrite lines 220-223**
+
+```python
+# Before
+    result = await session.execute(
+        select(RoomBookmark).where(RoomBookmark.room_id == source_room_id)
+    )
+    for row in result.scalars().all():
+
+# After
+    result = await session.exec(
+        select(RoomBookmark).where(RoomBookmark.room_id == source_room_id)
+    )
+    for row in result.all():
+```
+
+- [ ] **Step 3: Rewrite lines 233-236**
+
+```python
+# Before
+    result = await session.execute(
+        select(RoomFigure).where(RoomFigure.room_id == source_room_id)
+    )
+    for row in result.scalars().all():
+
+# After
+    result = await session.exec(
+        select(RoomFigure).where(RoomFigure.room_id == source_room_id)
+    )
+    for row in result.all():
+```
+
+- [ ] **Step 4: Rewrite lines 247-250**
+
+Read the 4 lines before the call to capture the exact model reference — it's one of `SelectionGroup`, `RoomFigure`, `RoomBookmark`, `RoomGeometry`. Apply the same pattern:
+
+```python
+# Before
+    result = await session.execute(
+        select(<Model>).where(<Model>.room_id == source_room_id)
+    )
+    for row in result.scalars().all():
+
+# After
+    result = await session.exec(
+        select(<Model>).where(<Model>.room_id == source_room_id)
+    )
+    for row in result.all():
+```
+
+- [ ] **Step 5: Rewrite lines 420-421**
+
+```python
+# Before
+    result = await session.execute(statement)
+    rooms = list(result.scalars().all())
+
+# After
+    result = await session.exec(statement)
+    rooms = list(result.all())
+```
+
+- [ ] **Step 6: Verify**
+
+Run:
+```bash
+grep -n "session\.execute\|scalar_one_or_none\|scalar_one\b\|\.scalars(" src/zndraw/routes/rooms.py
+```
+
+Expected: no output.
+
+- [ ] **Step 7: Run tests**
+
+Run:
+```bash
+uv run --active pytest tests/zndraw/test_admin.py tests/zndraw/test_rooms.py -q 2>&1 | tail -10
+```
+
+Expected: all tests pass. (test_admin covers room-copy via `test_create_room_uses_default_when_no_copy_from`.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/zndraw/routes/rooms.py
+git commit -m "$(cat <<'EOF'
+refactor(zndraw): migrate routes/rooms.py to session.exec() (#890)
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 9: Migrate `src/zndraw/routes/presets.py` (4 sites)
+
+**Files:**
+- Modify: `src/zndraw/routes/presets.py:100-103, 260, 269, 288`
+
+Module already imports `from sqlmodel import select` (line 9) — no import change.
+
+- [ ] **Step 1: Rewrite lines 100-103**
+
+```python
+# Before
+    result = await session.execute(
+        <statement>
+    )
+    rows = result.scalars().all()
+
+# After
+    result = await session.exec(
+        <statement>
+    )
+    rows = result.all()
+```
+
+Read the file to capture the exact statement — only change `execute` → `exec` and `result.scalars().all()` → `result.all()`.
+
+- [ ] **Step 2: Rewrite line 260 (one-liner)**
+
+```python
+# Before
+        existing = (await session.execute(stmt)).scalars().all()
+
+# After
+        existing = (await session.exec(stmt)).all()
+```
+
+- [ ] **Step 3: Rewrite line 269 (one-liner inside comprehension)**
+
+```python
+# Before
+        new_keys = [g.key for g in (await session.execute(new_stmt)).scalars().all()]
+
+# After
+        new_keys = [g.key for g in (await session.exec(new_stmt)).all()]
+```
+
+- [ ] **Step 4: Rewrite line 288 (one-liner)**
+
+```python
+# Before
+    geometries = (await session.execute(stmt)).scalars().all()
+
+# After
+    geometries = (await session.exec(stmt)).all()
+```
+
+- [ ] **Step 5: Verify**
+
+Run:
+```bash
+grep -n "session\.execute\|scalar_one_or_none\|scalar_one\b\|\.scalars(" src/zndraw/routes/presets.py
+```
+
+Expected: no output.
+
+- [ ] **Step 6: Run tests**
+
+Run:
+```bash
+uv run --active pytest tests/zndraw/test_presets.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/zndraw/routes/presets.py
+git commit -m "$(cat <<'EOF'
+refactor(zndraw): migrate routes/presets.py to session.exec() (#890)
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 10: Migrate `src/zndraw/routes/chat.py` (3 sites)
+
+**Files:**
+- Modify: `src/zndraw/routes/chat.py:78-79, 88, 94-97`
+
+Module already imports `from sqlmodel import col, select` (line 8). Keep `col` unchanged.
+
+- [ ] **Step 1: Rewrite lines 78-79**
+
+```python
+# Before
+    result = await session.execute(stmt)
+    rows = list(result.scalars().all())
+
+# After
+    result = await session.exec(stmt)
+    rows = list(result.all())
+```
+
+- [ ] **Step 2: Rewrite line 88 (count one-liner)**
+
+```python
+# Before
+    total_count = (await session.execute(count_stmt)).scalar_one()
+
+# After
+    total_count = (await session.exec(count_stmt)).one()
+```
+
+- [ ] **Step 3: Rewrite lines 94-97**
+
+```python
+# Before
+        users_result = await session.execute(
+            <statement>
+        )
+        for user in users_result.scalars().all():
+
+# After
+        users_result = await session.exec(
+            <statement>
+        )
+        for user in users_result.all():
+```
+
+Read the file to preserve the exact `<statement>` text.
+
+- [ ] **Step 4: Verify**
+
+Run:
+```bash
+grep -n "session\.execute\|scalar_one_or_none\|scalar_one\b\|\.scalars(" src/zndraw/routes/chat.py
+```
+
+Expected: no output.
+
+- [ ] **Step 5: Run tests**
+
+Run:
+```bash
+uv run --active pytest tests/zndraw/test_chat.py -q 2>&1 | tail -10
+```
+
+Expected: all tests pass (or "no tests ran" if no chat tests exist — still acceptable).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/zndraw/routes/chat.py
+git commit -m "$(cat <<'EOF'
+refactor(zndraw): migrate routes/chat.py to session.exec() (#890)
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 11: Migrate `src/zndraw/routes/screenshots.py` (2 sites)
+
+**Files:**
+- Modify: `src/zndraw/routes/screenshots.py:240-241, 248`
+
+Module already imports `from sqlmodel import col, select` (line 10). No import change.
+
+- [ ] **Step 1: Rewrite lines 240-241**
+
+```python
+# Before
+    result = await session.execute(stmt)
+    rows = list(result.scalars().all())
+
+# After
+    result = await session.exec(stmt)
+    rows = list(result.all())
+```
+
+- [ ] **Step 2: Rewrite line 248**
+
+```python
+# Before
+    total = (await session.execute(count_stmt)).scalar_one()
+
+# After
+    total = (await session.exec(count_stmt)).one()
+```
+
+- [ ] **Step 3: Verify**
+
+Run:
+```bash
+grep -n "session\.execute\|scalar_one_or_none\|scalar_one\b\|\.scalars(" src/zndraw/routes/screenshots.py
+```
+
+Expected: no output.
+
+- [ ] **Step 4: Run tests**
+
+Run:
+```bash
+uv run --active pytest tests/zndraw/test_screenshots.py -q 2>&1 | tail -10
+```
+
+Expected: tests pass (or "no tests ran").
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/zndraw/routes/screenshots.py
+git commit -m "$(cat <<'EOF'
+refactor(zndraw): migrate routes/screenshots.py to session.exec() (#890)
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 12: Migrate `src/zndraw/routes/geometries.py` (1 site)
+
+**Files:**
+- Modify: `src/zndraw/routes/geometries.py:107-110`
+
+Module already imports `from sqlmodel import select` (line 9). No import change.
+
+- [ ] **Step 1: Rewrite lines 107-110**
+
+```python
+# Before
+    result = await session.execute(
+        <statement>
+    )
+    rows = result.scalars().all()
+
+# After
+    result = await session.exec(
+        <statement>
+    )
+    rows = result.all()
+```
+
+Read the file to preserve the exact `<statement>`.
+
+- [ ] **Step 2: Verify**
+
+Run:
+```bash
+grep -n "session\.execute\|scalar_one_or_none\|scalar_one\b\|\.scalars(" src/zndraw/routes/geometries.py
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Run tests**
+
+Run:
+```bash
+uv run --active pytest tests/zndraw/test_geometries.py -q 2>&1 | tail -10
+```
+
+Expected: tests pass (or "no tests ran").
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/zndraw/routes/geometries.py
+git commit -m "$(cat <<'EOF'
+refactor(zndraw): migrate routes/geometries.py to session.exec() (#890)
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 13: Migrate `src/zndraw/routes/figures.py` (1 site)
+
+**Files:**
+- Modify: `src/zndraw/routes/figures.py:46-49`
+
+Module already imports `from sqlmodel import select` (line 4). No import change.
+
+- [ ] **Step 1: Rewrite lines 46-49**
+
+```python
+# Before
+    result = await session.execute(
+        <statement>
+    )
+    keys = list(result.scalars().all())
+
+# After
+    result = await session.exec(
+        <statement>
+    )
+    keys = list(result.all())
+```
+
+- [ ] **Step 2: Verify**
+
+Run:
+```bash
+grep -n "session\.execute\|scalar_one_or_none\|scalar_one\b\|\.scalars(" src/zndraw/routes/figures.py
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Run tests**
+
+Run:
+```bash
+uv run --active pytest tests/zndraw/test_figures.py -q 2>&1 | tail -10
+```
+
+Expected: tests pass (or "no tests ran").
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/zndraw/routes/figures.py
+git commit -m "$(cat <<'EOF'
+refactor(zndraw): migrate routes/figures.py to session.exec() (#890)
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 14: Migrate `src/zndraw/routes/selection_groups.py` (1 site)
+
+**Files:**
+- Modify: `src/zndraw/routes/selection_groups.py:50-54`
+
+This file has a **local** `from sqlmodel import select` inside the function (line 48). No module-level import change.
+
+- [ ] **Step 1: Rewrite lines 50-54**
+
+```python
+# Before
+    result = await session.execute(
+        select(SelectionGroup).where(SelectionGroup.room_id == room_id)
+    )
+    groups: dict[str, dict[str, list[int]]] = {}
+    for row in result.scalars().all():
+
+# After
+    result = await session.exec(
+        select(SelectionGroup).where(SelectionGroup.room_id == room_id)
+    )
+    groups: dict[str, dict[str, list[int]]] = {}
+    for row in result.all():
+```
+
+- [ ] **Step 2: Verify**
+
+Run:
+```bash
+grep -n "session\.execute\|scalar_one_or_none\|scalar_one\b\|\.scalars(" src/zndraw/routes/selection_groups.py
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Run tests**
+
+Run:
+```bash
+uv run --active pytest tests/zndraw/test_selection_groups.py -q 2>&1 | tail -10
+```
+
+Expected: tests pass (or "no tests ran").
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/zndraw/routes/selection_groups.py
+git commit -m "$(cat <<'EOF'
+refactor(zndraw): migrate routes/selection_groups.py to session.exec() (#890)
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 15: Migrate `src/zndraw/routes/bookmarks.py` (1 site)
+
+**Files:**
+- Modify: `src/zndraw/routes/bookmarks.py:44-47`
+
+Module already imports `from sqlmodel import select` (line 4). No import change.
+
+- [ ] **Step 1: Rewrite lines 44-47**
+
+```python
+# Before
+    result = await session.execute(
+        <statement>
+    )
+    rows = result.scalars().all()
+
+# After
+    result = await session.exec(
+        <statement>
+    )
+    rows = result.all()
+```
+
+Read the file to preserve the exact `<statement>`.
+
+- [ ] **Step 2: Verify**
+
+Run:
+```bash
+grep -n "session\.execute\|scalar_one_or_none\|scalar_one\b\|\.scalars(" src/zndraw/routes/bookmarks.py
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Run tests**
+
+Run:
+```bash
+uv run --active pytest tests/zndraw/test_bookmarks.py -q 2>&1 | tail -10
+```
+
+Expected: tests pass (or "no tests ran").
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/zndraw/routes/bookmarks.py
+git commit -m "$(cat <<'EOF'
+refactor(zndraw): migrate routes/bookmarks.py to session.exec() (#890)
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 16: Migrate `src/zndraw/routes/frames.py` (1 site — drop `sa_select` alias)
+
+**Files:**
+- Modify: `src/zndraw/routes/frames.py:17, 87-93, 88`
+
+This file has a `sa_select` alias. There is only one call site (line 88), so the alias can be removed entirely.
+
+- [ ] **Step 1: Swap the import at line 17**
+
+```python
+# Before
+from sqlalchemy import select as sa_select
+
+# After
+from sqlmodel import select
+```
+
+- [ ] **Step 2: Rewrite line 88**
+
+```python
+# Before
+        sa_select(ProviderRecord).where(
+
+# After
+        select(ProviderRecord).where(
+```
+
+- [ ] **Step 3: Rewrite lines 87 + 93**
+
+```python
+# Before (lines 87-93)
+    result = await session.execute(
+        select(ProviderRecord).where(
+            <filters>
+        )
+    )
+    return result.scalar_one_or_none()
+
+# After
+    result = await session.exec(
+        select(ProviderRecord).where(
+            <filters>
+        )
+    )
+    return result.one_or_none()
+```
+
+- [ ] **Step 4: Verify no `sa_select` or old patterns remain**
+
+Run:
+```bash
+grep -n "sa_select\|session\.execute\|scalar_one_or_none\|scalar_one\b\|\.scalars(" src/zndraw/routes/frames.py
+```
+
+Expected: no output.
+
+- [ ] **Step 5: Run tests**
+
+Run:
+```bash
+uv run --active pytest tests/zndraw/test_frames.py -q 2>&1 | tail -10
+```
+
+Expected: tests pass (or "no tests ran").
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/zndraw/routes/frames.py
+git commit -m "$(cat <<'EOF'
+refactor(zndraw): migrate routes/frames.py to session.exec() (#890)
+
+Drops the sa_select alias — the only call site migrates to sqlmodel's
+select via session.exec().
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 17: Migrate `src/zndraw_auth/db.py` (1 site)
+
+**Files:**
+- Modify: `src/zndraw_auth/db.py:12, 161-164`
+
+Module imports `from sqlalchemy import select` (line 12). Swap to sqlmodel.
+
+- [ ] **Step 1: Swap the import at line 12**
+
+```python
+# Before
+from sqlalchemy import select
+
+# After
+from sqlmodel import select
+```
+
+- [ ] **Step 2: Rewrite lines 161-164**
+
+```python
+# Before
+    result = await session.execute(
+        <statement>
+    )
+    existing = result.scalar_one_or_none()
+
+# After
+    result = await session.exec(
+        <statement>
+    )
+    existing = result.one_or_none()
+```
+
+Read the file to preserve the exact `<statement>`.
+
+- [ ] **Step 3: Verify**
+
+Run:
+```bash
+grep -n "session\.execute\|scalar_one_or_none\|scalar_one\b\|\.scalars(" src/zndraw_auth/db.py
+```
+
+Expected: no output.
+
+- [ ] **Step 4: Run tests**
+
+Run:
+```bash
+uv run --active pytest tests/zndraw_auth/ -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/zndraw_auth/db.py
+git commit -m "$(cat <<'EOF'
+refactor(auth): migrate db.py to session.exec() (#890)
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 18: Migrate `src/zndraw_auth/cli_login.py` (3 sites)
+
+**Files:**
+- Modify: `src/zndraw_auth/cli_login.py:12, 68, 71, 121, 124, 155, 158`
+
+Module imports `from sqlalchemy import select` (line 12). Swap to sqlmodel.
+
+- [ ] **Step 1: Swap the import at line 12**
+
+```python
+# Before
+from sqlalchemy import select
+
+# After
+from sqlmodel import select
+```
+
+- [ ] **Step 2: Rewrite lines 68-71**
+
+```python
+# Before
+    result = await session.execute(
+        <statement>
+    )
+    challenge = result.scalar_one_or_none()
+
+# After
+    result = await session.exec(
+        <statement>
+    )
+    challenge = result.one_or_none()
+```
+
+- [ ] **Step 3: Rewrite lines 121-124**
+
+Same pattern as Step 2 — different `<statement>`. Read the file to capture it verbatim.
+
+```python
+# Before
+    result = await session.execute(
+        <statement>
+    )
+    challenge = result.scalar_one_or_none()
+
+# After
+    result = await session.exec(
+        <statement>
+    )
+    challenge = result.one_or_none()
+```
+
+- [ ] **Step 4: Rewrite lines 155-158**
+
+Same pattern as Steps 2-3 — different `<statement>`.
+
+```python
+# Before
+    result = await session.execute(
+        <statement>
+    )
+    challenge = result.scalar_one_or_none()
+
+# After
+    result = await session.exec(
+        <statement>
+    )
+    challenge = result.one_or_none()
+```
+
+- [ ] **Step 5: Verify**
+
+Run:
+```bash
+grep -n "session\.execute\|scalar_one_or_none\|scalar_one\b\|\.scalars(" src/zndraw_auth/cli_login.py
+```
+
+Expected: no output.
+
+- [ ] **Step 6: Run tests**
+
+Run:
+```bash
+uv run --active pytest tests/zndraw_auth/ -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/zndraw_auth/cli_login.py
+git commit -m "$(cat <<'EOF'
+refactor(auth): migrate cli_login.py to session.exec() (#890)
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 19: Add the `filterwarnings` gate
+
+**Files:**
+- Modify: `pyproject.toml:222-226` (`[tool.pytest.ini_options]` block)
+
+Adds the regression guard. This commit lands **last** so every earlier commit bisects against a green baseline.
+
+- [ ] **Step 1: Read the current `[tool.pytest.ini_options]` block**
+
+Run:
+```bash
+grep -nA 10 "\[tool.pytest.ini_options\]" pyproject.toml
+```
+
+Expected: the current block has `testpaths`, `asyncio_mode`, `asyncio_default_fixture_loop_scope`, `markers`. No existing `filterwarnings`.
+
+- [ ] **Step 2: Add the `filterwarnings` entry**
+
+Append to the block (after the `markers` line):
+
+```toml
+[tool.pytest.ini_options]
+testpaths = ["tests/zndraw", "tests/zndraw_auth", "tests/zndraw_joblib"]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
+markers = ["integration: marks tests as integration tests (require running server)"]
+filterwarnings = [
+    'error:[\s\S]*You probably want to use .session\.exec:DeprecationWarning',
+]
+```
+
+**Why single quotes:** avoids double-backslashing the regex in TOML.
+**Why `[\s\S]*`:** the SQLModel deprecation message begins with `\n    🚨 You probably...`. Python's `warnings.filterwarnings` compiles the regex without DOTALL, so `.` doesn't cross newlines. `[\s\S]*` matches across newlines without needing literal emoji or whitespace in the pattern.
+**Why message-regex (not module):** `typing_extensions.@deprecated` uses `stacklevel=2`, so the warning's `module` attribute points to the calling code (e.g. `zndraw_joblib.registry`), not to `sqlmodel.*`. Filtering by module would silently match nothing.
+
+- [ ] **Step 3: Verify the filter works on a single small test file**
+
+Run:
+```bash
+uv run --active pytest tests/zndraw_joblib/test_registry.py -q
+```
+
+Expected: `8 passed`, no warnings (confirming no leftover src/ call sites are exercised by this file).
+
+- [ ] **Step 4: Run the full test suite to catch any missed call site**
+
+Run:
+```bash
+uv run --active pytest tests/ 2>&1 | tail -30
+```
+
+Expected: all tests pass, **0 warnings**. If a test fails with `DeprecationWarning` escalated to error, the failure traceback will point at the file and line of the missed `session.execute()`. Fix it in the already-committed file-level commit (amend via `git commit --fixup=<sha>` + interactive rebase, OR add a follow-up `fix:` commit).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pyproject.toml
+git commit -m "$(cat <<'EOF'
+chore(ci): error on sqlmodel session.execute deprecation warning (#890)
+
+Escalate the SQLModel session.execute() DeprecationWarning to an error
+in pytest so any regression into the deprecated API fails CI loudly.
+
+Scoped by message regex (not module) because typing_extensions.@deprecated
+uses stacklevel=2, which attributes the warning to the calling code.
+The [\\s\\S]* prefix handles the leading newline/emoji of the SQLModel
+message since Python's warnings filter compiles regex without DOTALL.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 20: Final verification, push, and PR
+
+**Files:**
+- None modified.
+
+- [ ] **Step 1: Full test suite pass with zero warnings**
+
+Run:
+```bash
+uv run --active pytest tests/ 2>&1 | tail -5
+```
+
+Expected: all tests pass, warning count shows `0 warnings` or no warning summary at all.
+
+- [ ] **Step 2: Confirm no leftover `session.execute()` in `src/`**
+
+Run:
+```bash
+grep -rn "session\.execute(" src/ || echo "CLEAN"
+```
+
+Expected: `CLEAN` (no matches).
+
+- [ ] **Step 3: Confirm no leftover `.scalars()` cruft in `src/`**
+
+Run:
+```bash
+grep -rn "\.scalars(" src/ || echo "CLEAN"
+```
+
+Expected: `CLEAN`.
+
+- [ ] **Step 4: Review the commit log**
+
+Run:
+```bash
+git log --oneline main..HEAD
+```
+
+Expected: 19 commits (1 docs spec, 17 per-file migrations, 1 filterwarnings gate).
+
+- [ ] **Step 5: Push the branch**
+
+```bash
+git push -u origin worktree-fix+sqlmodel-session-exec-migration
+```
+
+- [ ] **Step 6: Open the PR**
+
+```bash
+gh pr create --title "fix: migrate to SQLModel session.exec() and gate regressions (#890)" --body "$(cat <<'EOF'
+## Summary
+
+- Migrate all 77 `session.execute()` call sites across 17 files in `src/` to SQLModel's `session.exec()` API — the SOTA recommendation per sqlmodel.tiangolo.com.
+- Eliminates 15,000+ `DeprecationWarning` instances per test run that were drowning out real warnings in CI.
+- Adds a `pyproject.toml` `filterwarnings` gate that escalates any future `session.execute()` reintroduction (on a SQLModel session) to a hard CI failure.
+
+Closes #890.
+
+## Approach
+
+- Per-file atomic commits so bisection is trivial if a regression slips through.
+- No behavioral changes. `session.exec()` returns the same data via `.one()` / `.one_or_none()` / `.all()` instead of `.scalar_one()` / `.scalar_one_or_none()` / `.scalars().all()`.
+- The one bulk `update(Task).where(...).values(...)` call in `router.py` (optimistic-locking task-claim path) uses SQLModel's `UpdateBase` overload on `exec()`, which returns a fully-typed `CursorResult` with `.rowcount` — no type-ignore, no mixing with raw SQLAlchemy execute.
+- Test files are untouched. Empirical verification showed test fixtures create pure `sqlalchemy.ext.asyncio.AsyncSession` instances, which never trigger SQLModel's deprecated wrapper. The 15k warnings all originate from `src/` code exercised via integration tests that go through the production `SQLModelAsyncSession` factory.
+
+Spec: `docs/superpowers/specs/2026-04-08-sqlmodel-session-exec-migration-design.md`
+Plan: `docs/superpowers/plans/2026-04-08-sqlmodel-session-exec-migration.md`
+
+## Test plan
+
+- [x] `uv run pytest tests/` passes with 0 warnings.
+- [x] `grep -rn "session\\.execute(" src/` returns empty.
+- [x] `grep -rn "\\.scalars(" src/` returns empty.
+- [x] The `filterwarnings` gate is in effect (a deliberate `session.execute()` in any `src/` file now fails the suite with a clear traceback).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 7: Return PR URL**
+
+Capture the URL printed by `gh pr create` and report it to the user.
+
+---
+
+## Self-review
+
+- **Spec coverage:** Every file in the spec's 17-file inventory has a dedicated task (Tasks 2-18). The `pyproject.toml` filter is Task 19. Final verification + PR is Task 20. The baseline verification (Task 1) covers the spec's "Verification" section (run tests, establish green baseline). All rewrite rules from the spec (Rules 1-7) are inlined in the "Rewrite rules" reference at the top of the plan and invoked by name in each task's "Rules invoked" column.
+- **Placeholder scan:** The `<statement>` placeholders in Tasks 6, 9, 10, 12, 13, 15, 17, 18 are intentional and marked with an instruction to read the file and preserve the exact text. This is not a "TODO" — the mechanical transformation (`execute` → `exec`, `scalar_one_or_none` → `one_or_none`, etc.) is fully specified; only the enclosed statement (which is a 2-5 line SELECT expression) is to be copied verbatim from the existing code. An engineer can perform this without judgment calls.
+- **Type consistency:** `session.exec()`, `one_or_none()`, `one()`, `all()` are spelled identically in every task. `.rowcount` is only used in Task 5 Step 5 (Rule 6, bulk update) — consistent with SQLModel's `UpdateBase` overload signature from the spec.
+- **Commit atomicity:** Every task produces exactly one commit except Task 1 (no commit — read-only baseline) and Task 20 (no commit — push + PR only). Total commits: 19 (1 spec docs already committed + 17 file migrations + 1 filterwarnings gate).
+
+## Execution handoff
+
+**Plan complete and saved to `docs/superpowers/plans/2026-04-08-sqlmodel-session-exec-migration.md`. Two execution options:**
+
+**1. Subagent-Driven (recommended)** — dispatch a fresh subagent per task, review between tasks, fast iteration.
+
+**2. Inline Execution** — execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+**Which approach?**

--- a/docs/superpowers/specs/2026-04-08-sqlmodel-session-exec-migration-design.md
+++ b/docs/superpowers/specs/2026-04-08-sqlmodel-session-exec-migration-design.md
@@ -14,9 +14,7 @@ Beyond noise reduction, the SQLModel upstream recommendation (verified via conte
 
 ## Scope
 
-Full inventory of `session.execute()` call sites across the repo (as of 2026-04-08):
-
-### `src/` — 77 sites across 17 files
+Full inventory of `session.execute()` call sites in `src/` — **77 sites across 17 files** (as of 2026-04-08):
 
 | File | Call sites |
 |---|---|
@@ -38,18 +36,17 @@ Full inventory of `session.execute()` call sites across the repo (as of 2026-04-
 | `src/zndraw_auth/db.py` | 1 |
 | `src/zndraw_auth/cli_login.py` | 3 |
 
-### `tests/` — 25 sites across 4 files
+### Why `tests/` is excluded
 
-| File | Call sites |
-|---|---|
-| `tests/zndraw_joblib/test_sweeper.py` | 16 |
-| `tests/zndraw_joblib/test_resilience.py` | 6 |
-| `tests/zndraw_joblib/test_registry.py` | 2 |
-| `tests/zndraw_auth/conftest.py` | 1 |
+Initial concern: with `filterwarnings = error`, untouched `session.execute()` calls in tests would break CI. **Verified empirically that they will not.**
 
-**Total: 102 sites across 21 files.** Tests must be migrated too — with `filterwarnings = error`, any untouched test call site would fail the suite. Any test marked `@pytest.mark.protected` stays untouched per project rules; if one blocks the migration, we document it and carve a narrow per-test `filterwarnings` marker rather than weakening the global filter.
+Every test fixture in the repo creates sessions via `async_sessionmaker(..., class_=AsyncSession)` where `AsyncSession` is imported from `sqlalchemy.ext.asyncio` — **pure SQLAlchemy sessions** (conftest files: `tests/zndraw/conftest.py:17`, `tests/zndraw_joblib/conftest.py:15`, `tests/zndraw_auth/conftest.py:11`, and `tests/zndraw_joblib/test_resilience.py` which builds its own `async_sessionmaker(threadsafe_engine, class_=AsyncSession)` per-call).
 
-**Out of scope:** anything outside the repo. `src/zndraw/socketio.py` already uses `session.exec()` and serves as a reference pattern.
+SQLModel's deprecation warning lives only on `sqlmodel.ext.asyncio.session.AsyncSession.execute`. Pure SQLAlchemy sessions bypass the override entirely (verified via `warnings.catch_warnings()` probe on both session classes). The 25 direct `session.execute()` calls in `tests/zndraw_joblib/test_sweeper.py` (16), `tests/zndraw_joblib/test_resilience.py` (6), `tests/zndraw_joblib/test_registry.py` (2), and `tests/zndraw_auth/conftest.py` (1) therefore emit **zero** warnings — confirmed by running those files with `-W 'error:...:DeprecationWarning'`: 24 passed, 0 warnings.
+
+The 15k warnings observed in the full test suite come from **integration tests** that spin up a real uvicorn server via the `server` fixture in `tests/zndraw/conftest.py:300`. That server boots through `src/zndraw/database.py:205`, which configures the production session maker with `class_=SQLModelAsyncSession`. Those tests trigger warnings only from the `src/` code they hit over HTTP, not from test-level code. Migrating `src/` eliminates all 15k.
+
+**Out of scope:** all `tests/**` (no warning exposure, so no failure risk under the filter), anything outside the repo. `src/zndraw/socketio.py` already uses `session.exec()` and serves as a reference pattern.
 
 ## Source-verified foundations
 
@@ -184,12 +181,12 @@ Notes:
 ## Execution shape
 
 - Single branch in a dedicated worktree at `.claude/worktrees/fix+sqlmodel-session-exec-migration`.
-- **Commit shape:** per-file commits for `src/` (17), per-file commits for `tests/` (4), plus one final `chore(ci): error on sqlmodel session.execute deprecation warning` that introduces the `filterwarnings` gate. The gate commit lands **last** so the per-file commits bisect cleanly against a non-failing baseline.
+- **Commit shape:** 17 per-file commits for `src/`, plus one final `chore(ci): error on sqlmodel session.execute deprecation warning` that introduces the `filterwarnings` gate. The gate commit lands **last** so the per-file commits bisect cleanly against a non-failing baseline.
 - Final step: `uv run pytest tests/` must pass cleanly, then open a PR against `main`.
 
 ## Non-goals
 
+- Migrating any `session.execute()` in `tests/**`. They don't emit the SQLModel deprecation warning (fixture sessions are pure SQLAlchemy), so they won't fail under the `filterwarnings = error` gate. Left untouched.
 - Converting any `session.execute()` that lives outside the repo.
 - Migrating ORM-style `session.add()` / `session.delete()` / `session.get()` calls (these are already the SOTA pattern).
 - Adding new tests — the migration is mechanical and existing coverage is adequate.
-- Modifying tests marked `@pytest.mark.protected` — none of the affected test files carry this marker (verified 2026-04-08), so this is a no-op constraint, but remains a hard rule per project instructions.

--- a/docs/superpowers/specs/2026-04-08-sqlmodel-session-exec-migration-design.md
+++ b/docs/superpowers/specs/2026-04-08-sqlmodel-session-exec-migration-design.md
@@ -1,0 +1,183 @@
+# Migrate `src/` to SQLModel `session.exec()`
+
+**Date:** 2026-04-08
+**Related issue:** [zincware/ZnDraw#890](https://github.com/zincware/ZnDraw/issues/890)
+**Status:** Approved, ready for implementation
+
+## Problem
+
+SQLModel's `AsyncSession.execute()` is decorated with `@typing_extensions.deprecated(...)` and emits a `DeprecationWarning` on every call. Across `src/`, there are **77 call sites in 17 files**, producing 15,000+ warnings per test run and drowning out real warnings in CI.
+
+The GitHub issue names `zndraw_joblib/registry.py:108` as the exemplar, but patching only that line leaves the vast majority of warnings untouched. The joblib, zndraw, and zndraw_auth packages are now all part of `src/` in the same repo; any migration must cover all three or a CI warning filter would fail on unmigrated files.
+
+Beyond noise reduction, the SQLModel upstream recommendation (verified via context7 against sqlmodel.tiangolo.com) is unambiguous: **"It is recommended to always use `session.exec()`."** It auto-handles `.scalars()` for SELECT statements, provides proper editor autocompletion, typed results, and inline error checking. This is both a deprecation fix *and* an SOTA alignment.
+
+## Scope
+
+Full inventory of `session.execute()` call sites under `src/` (as of 2026-04-08):
+
+| File | Call sites |
+|---|---|
+| `src/zndraw_joblib/router.py` | 40 |
+| `src/zndraw_joblib/sweeper.py` | 9 |
+| `src/zndraw_joblib/registry.py` | 1 |
+| `src/zndraw_joblib/dependencies.py` | 1 |
+| `src/zndraw/routes/rooms.py` | 5 |
+| `src/zndraw/routes/presets.py` | 4 |
+| `src/zndraw/routes/chat.py` | 3 |
+| `src/zndraw/routes/admin.py` | 2 |
+| `src/zndraw/routes/screenshots.py` | 2 |
+| `src/zndraw/routes/geometries.py` | 1 |
+| `src/zndraw/routes/figures.py` | 1 |
+| `src/zndraw/routes/selection_groups.py` | 1 |
+| `src/zndraw/routes/bookmarks.py` | 1 |
+| `src/zndraw/routes/frames.py` | 1 |
+| `src/zndraw/database.py` | 1 |
+| `src/zndraw_auth/db.py` | 1 |
+| `src/zndraw_auth/cli_login.py` | 3 |
+| **Total** | **77 across 17 files** |
+
+**Out of scope:** `tests/**`, everything outside `src/`. `src/zndraw/socketio.py` already uses `session.exec()` and serves as a reference pattern.
+
+## Source-verified foundations
+
+Reading `sqlmodel/ext/asyncio/session.py` directly, `AsyncSession.exec()` has three overloads:
+
+```python
+@overload
+async def exec(self, statement: Select[_T], ...) -> TupleResult[_T]: ...
+@overload
+async def exec(self, statement: SelectOfScalar[_T], ...) -> ScalarResult[_T]: ...
+@overload
+async def exec(self, statement: UpdateBase, ...) -> CursorResult[Any]: ...
+```
+
+Consequences:
+
+1. SELECT-of-model returns a `ScalarResult` with `.one()`, `.one_or_none()`, `.first()`, `.all()`, and direct iteration — no manual `.scalars()`.
+2. **Bulk `update()` / `delete()` are first-class** via the `UpdateBase` overload and return `CursorResult[Any]` with `.rowcount`. No type ignore, no mixing with raw `session.execute()`, no fallback needed.
+3. The deprecation warning is raised by `@typing_extensions.deprecated` on the `execute()` method (line 109 of `sqlmodel/ext/asyncio/session.py`). It does **not** fire on `exec()`.
+4. `typing_extensions.deprecated` uses `stacklevel=2`, which makes the warning's `module` attribute resolve to the **caller's** module (e.g. `zndraw_joblib.registry`), not to `sqlmodel.*`. This has implications for the CI warning filter — see below.
+
+## Mechanical rewrite rules
+
+All patterns below are derived from actual call sites in the codebase.
+
+### Rule 1 — Imports
+
+Swap `select` to the SQLModel re-export. Keep everything else from sqlalchemy — SQLModel does not re-export `func`, `and_`, `or_`, `update`, `delete`, etc., and they interop transparently.
+
+```python
+# Before
+from sqlalchemy import func, select, update
+
+# After
+from sqlalchemy import func, update
+from sqlmodel import select
+```
+
+### Rule 2 — SELECT returning model instances
+
+| Before | After |
+|---|---|
+| `result = await session.execute(select(Model).where(...))`<br>`obj = result.scalar_one_or_none()` | `result = await session.exec(select(Model).where(...))`<br>`obj = result.one_or_none()` |
+| `result = await session.execute(select(Model).where(...))`<br>`obj = result.scalar_one()` | `result = await session.exec(select(Model).where(...))`<br>`obj = result.one()` |
+| `result = await session.execute(select(Model).where(...))`<br>`rows = result.scalars().all()` | `result = await session.exec(select(Model).where(...))`<br>`rows = result.all()` |
+| `rows = (await session.execute(stmt)).scalars().all()` | `rows = (await session.exec(stmt)).all()` |
+| `total = (await session.execute(count_stmt)).scalar_one()` | `total = (await session.exec(count_stmt)).one()` |
+
+### Rule 3 — SELECT aggregates (`func.count()`)
+
+```python
+# Before
+total_result = await session.execute(select(func.count()).select_from(Worker))
+total = total_result.scalar()
+
+# After
+total_result = await session.exec(select(func.count()).select_from(Worker))
+total = total_result.one()
+```
+
+`.one()` on a count query returns the integer directly.
+
+### Rule 4 — Bulk `update()` / `delete()`
+
+There is exactly one site in the codebase (`src/zndraw_joblib/router.py:733`) that uses a bulk `update(Task).where(...).values(...)` statement for optimistic task-claiming. SQLModel's `exec()` accepts `UpdateBase` statements natively via the third overload; the return type is `CursorResult[Any]` with `.rowcount` intact.
+
+```python
+# Before
+stmt = update(Task).where(Task.id == task_id, Task.status == TaskStatus.PENDING).values(...)
+cursor_result = await session.execute(stmt)
+if cursor_result.rowcount == 1:
+    ...
+
+# After
+stmt = update(Task).where(Task.id == task_id, Task.status == TaskStatus.PENDING).values(...)
+cursor_result = await session.exec(stmt)
+if cursor_result.rowcount == 1:
+    ...
+```
+
+No type ignore, no `# noqa`, no SQLAlchemy/SQLModel mixing. This preserves the atomic optimistic-locking semantics the task-claim path depends on.
+
+### Rule 5 — Iteration patterns
+
+Where code iterates over a result:
+
+```python
+# Before
+for row in (await session.execute(select(Model))).scalars():
+    ...
+
+# After
+for row in await session.exec(select(Model)):
+    ...
+```
+
+## Regression guard
+
+Add to `[tool.pytest.ini_options]` in `pyproject.toml`:
+
+```toml
+filterwarnings = [
+    'error:[\s\S]*You probably want to use .session\.exec:DeprecationWarning',
+]
+```
+
+Notes:
+
+- **Why message-based, not module-based.** `typing_extensions.@deprecated` uses `stacklevel=2`, so the warning's `module` attribute points to the calling code (e.g. `zndraw_joblib.registry`), not to `sqlmodel.*`. A `:sqlmodel.*:` filter would silently match nothing. Message-regex is the only reliable scoping.
+- **Why `[\s\S]*` at the start.** The SQLModel deprecation message is a triple-quoted string that begins with `\n    🚨 You probably want to use...`. Python's `warnings.filterwarnings` compiles the regex without DOTALL, so `.` doesn't cross newlines. `[\s\S]*` matches the leading whitespace/emoji without needing to literal-match them.
+- **Why TOML single-quoted.** Avoids double-backslashing the regex.
+- **Effect.** Any reintroduction of `session.execute()` anywhere in `src/` (or in tests) becomes a hard CI failure with a clear message pointing at the culprit.
+
+## Verification
+
+- Run the full test suite via `uv run pytest tests/`.
+- The existing suite already exercises every migrated code path — the 15k warning count is proof of coverage.
+- Expected outcome: warning count goes from 15,000+ to 0.
+- The `filterwarnings = error` gate converts any missed site into a hard test failure, pointing at the exact file and line.
+- No new unit tests. The migration is mechanical and adding per-file tests would duplicate existing coverage.
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Missed call site silently slips through | `filterwarnings = error` converts it to a hard test failure |
+| Aggregate `.one()` misbehaves on a count query | Admin/router count endpoints are under test; any divergence surfaces as a failing test |
+| Complex selects (joins, subqueries, `select_from`, window functions) interact badly with sqlmodel's `select` | `sqlmodel.select` is a thin wrapper over sqlalchemy's — joins/subqueries/aggregates pass through identically per source inspection |
+| Missing `and_`/`or_`/`update` imports after the `select` swap | Grep each file post-edit; the existing imports of these helpers stay put on the sqlalchemy import line |
+| Test-order dependency caused by warning escalation | Warning is emitted synchronously on each call; no cross-test state |
+
+## Execution shape
+
+- Single branch: `fix/sqlmodel-session-exec-migration` in a dedicated worktree at `.claude/worktrees/fix+sqlmodel-session-exec-migration`.
+- **Commit shape:** per-file commits (17), each `refactor(<pkg>): migrate <file> to session.exec()`, plus one final `chore(ci): error on sqlmodel session.execute deprecation warning`. Keeps bisection simple if something regresses.
+- Final step: `uv run pytest tests/` must pass cleanly, then open a PR against `main`.
+
+## Non-goals
+
+- Touching test code (tests may still use `session.execute()` — the `filterwarnings` filter catches that too, so any test regressions show up naturally).
+- Converting any `session.execute()` that lives outside `src/`.
+- Migrating ORM-style `session.add()` / `session.delete()` / `session.get()` calls (these are already the SOTA pattern).
+- Adding new tests — the migration is mechanical and existing coverage is adequate.

--- a/docs/superpowers/specs/2026-04-08-sqlmodel-session-exec-migration-design.md
+++ b/docs/superpowers/specs/2026-04-08-sqlmodel-session-exec-migration-design.md
@@ -14,7 +14,9 @@ Beyond noise reduction, the SQLModel upstream recommendation (verified via conte
 
 ## Scope
 
-Full inventory of `session.execute()` call sites under `src/` (as of 2026-04-08):
+Full inventory of `session.execute()` call sites across the repo (as of 2026-04-08):
+
+### `src/` — 77 sites across 17 files
 
 | File | Call sites |
 |---|---|
@@ -35,9 +37,19 @@ Full inventory of `session.execute()` call sites under `src/` (as of 2026-04-08)
 | `src/zndraw/database.py` | 1 |
 | `src/zndraw_auth/db.py` | 1 |
 | `src/zndraw_auth/cli_login.py` | 3 |
-| **Total** | **77 across 17 files** |
 
-**Out of scope:** `tests/**`, everything outside `src/`. `src/zndraw/socketio.py` already uses `session.exec()` and serves as a reference pattern.
+### `tests/` — 25 sites across 4 files
+
+| File | Call sites |
+|---|---|
+| `tests/zndraw_joblib/test_sweeper.py` | 16 |
+| `tests/zndraw_joblib/test_resilience.py` | 6 |
+| `tests/zndraw_joblib/test_registry.py` | 2 |
+| `tests/zndraw_auth/conftest.py` | 1 |
+
+**Total: 102 sites across 21 files.** Tests must be migrated too — with `filterwarnings = error`, any untouched test call site would fail the suite. Any test marked `@pytest.mark.protected` stays untouched per project rules; if one blocks the migration, we document it and carve a narrow per-test `filterwarnings` marker rather than weakening the global filter.
+
+**Out of scope:** anything outside the repo. `src/zndraw/socketio.py` already uses `session.exec()` and serves as a reference pattern.
 
 ## Source-verified foundations
 
@@ -171,13 +183,13 @@ Notes:
 
 ## Execution shape
 
-- Single branch: `fix/sqlmodel-session-exec-migration` in a dedicated worktree at `.claude/worktrees/fix+sqlmodel-session-exec-migration`.
-- **Commit shape:** per-file commits (17), each `refactor(<pkg>): migrate <file> to session.exec()`, plus one final `chore(ci): error on sqlmodel session.execute deprecation warning`. Keeps bisection simple if something regresses.
+- Single branch in a dedicated worktree at `.claude/worktrees/fix+sqlmodel-session-exec-migration`.
+- **Commit shape:** per-file commits for `src/` (17), per-file commits for `tests/` (4), plus one final `chore(ci): error on sqlmodel session.execute deprecation warning` that introduces the `filterwarnings` gate. The gate commit lands **last** so the per-file commits bisect cleanly against a non-failing baseline.
 - Final step: `uv run pytest tests/` must pass cleanly, then open a PR against `main`.
 
 ## Non-goals
 
-- Touching test code (tests may still use `session.execute()` — the `filterwarnings` filter catches that too, so any test regressions show up naturally).
-- Converting any `session.execute()` that lives outside `src/`.
+- Converting any `session.execute()` that lives outside the repo.
 - Migrating ORM-style `session.add()` / `session.delete()` / `session.get()` calls (these are already the SOTA pattern).
 - Adding new tests — the migration is mechanical and existing coverage is adequate.
+- Modifying tests marked `@pytest.mark.protected` — none of the affected test files carry this marker (verified 2026-04-08), so this is a no-op constraint, but remains a hard rule per project instructions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,6 +224,10 @@ testpaths = ["tests/zndraw", "tests/zndraw_auth", "tests/zndraw_joblib"]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 markers = ["integration: marks tests as integration tests (require running server)"]
+filterwarnings = [
+    'error:[\s\S]*You probably want to use .session\.exec:DeprecationWarning',
+    'ignore::DeprecationWarning:fastapi_users_db_sqlalchemy',
+]
 
 [tool.codespell]
 skip = "frontend/bun.lock,docs/source/_static/*.svg,.planning/*"

--- a/src/zndraw/database.py
+++ b/src/zndraw/database.py
@@ -20,7 +20,8 @@ import redis.asyncio as redis_client
 import socketio as socketio_lib
 from fastapi import FastAPI
 from fastapi_users.password import PasswordHelper
-from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker
+from sqlmodel.ext.asyncio.session import AsyncSession
 from sqlmodel import SQLModel, select
 from sqlmodel.ext.asyncio.session import AsyncSession as SQLModelAsyncSession
 from taskiq.api import run_receiver_task
@@ -110,10 +111,10 @@ async def ensure_internal_worker(
     """
     password_helper = PasswordHelper()
 
-    result = await session.execute(
+    result = await session.exec(
         select(User).where(User.email == email)  # type: ignore[arg-type]
     )
-    existing = result.scalar_one_or_none()
+    existing = result.one_or_none()
 
     hashed = password_helper.hash(str(uuid.uuid4()))
 

--- a/src/zndraw/database.py
+++ b/src/zndraw/database.py
@@ -21,9 +21,11 @@ import socketio as socketio_lib
 from fastapi import FastAPI
 from fastapi_users.password import PasswordHelper
 from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker
-from sqlmodel.ext.asyncio.session import AsyncSession
 from sqlmodel import SQLModel, select
-from sqlmodel.ext.asyncio.session import AsyncSession as SQLModelAsyncSession
+from sqlmodel.ext.asyncio.session import (
+    AsyncSession,
+    AsyncSession as SQLModelAsyncSession,
+)
 from taskiq.api import run_receiver_task
 from taskiq_redis import ListQueueBroker
 

--- a/src/zndraw/routes/admin.py
+++ b/src/zndraw/routes/admin.py
@@ -72,12 +72,12 @@ async def list_users(
     Requires admin privileges.
     """
     # Get total count
-    count_result = await session.execute(select(func.count()).select_from(User))
-    total = count_result.scalar_one()
+    count_result = await session.exec(select(func.count()).select_from(User))
+    total = count_result.one()
 
     # Get paginated users
-    result = await session.execute(select(User).offset(offset).limit(limit))
-    users = list(result.scalars().all())
+    result = await session.exec(select(User).offset(offset).limit(limit))
+    users = list(result.all())
 
     return OffsetPage(
         items=[AdminUserResponse.model_validate(u) for u in users],

--- a/src/zndraw/routes/bookmarks.py
+++ b/src/zndraw/routes/bookmarks.py
@@ -41,10 +41,10 @@ async def list_bookmarks(
 ) -> BookmarksResponse:
     """Get all bookmarks for a room."""
     await verify_room(session, room_id)
-    result = await session.execute(
+    result = await session.exec(
         select(RoomBookmark).where(RoomBookmark.room_id == room_id)
     )
-    rows = result.scalars().all()
+    rows = result.all()
     bookmarks = {str(row.frame_index): row.label for row in rows}
     return BookmarksResponse(items=bookmarks)
 

--- a/src/zndraw/routes/chat.py
+++ b/src/zndraw/routes/chat.py
@@ -75,8 +75,8 @@ async def list_messages(
 
     # Fetch one extra to determine has_more
     stmt = stmt.order_by(col(Message.created_at).desc()).limit(limit + 1)
-    result = await session.execute(stmt)
-    rows = list(result.scalars().all())
+    result = await session.exec(stmt)
+    rows = list(result.all())
 
     has_more = len(rows) > limit
     rows = rows[:limit]
@@ -85,16 +85,16 @@ async def list_messages(
     count_stmt = (
         select(func.count()).select_from(Message).where(Message.room_id == room_id)
     )
-    total_count = (await session.execute(count_stmt)).scalar_one()
+    total_count = (await session.exec(count_stmt)).one()
 
     # Look up emails for all user_ids
     user_ids = {row.user_id for row in rows}
     email_map: dict[str, str | None] = {}
     if user_ids:
-        users_result = await session.execute(
+        users_result = await session.exec(
             select(User).where(col(User.id).in_(user_ids))
         )
-        for user in users_result.scalars().all():
+        for user in users_result.all():
             email_map[str(user.id)] = user.email
 
     messages = [

--- a/src/zndraw/routes/figures.py
+++ b/src/zndraw/routes/figures.py
@@ -43,10 +43,10 @@ async def list_figures(
 ) -> CollectionResponse[str]:
     """List all figure keys in a room."""
     await verify_room(session, room_id)
-    result = await session.execute(
+    result = await session.exec(
         select(RoomFigure.key).where(RoomFigure.room_id == room_id)
     )
-    keys = list(result.scalars().all())
+    keys = list(result.all())
     return CollectionResponse(items=keys)
 
 

--- a/src/zndraw/routes/frames.py
+++ b/src/zndraw/routes/frames.py
@@ -14,8 +14,8 @@ from typing import Annotated
 
 import msgpack
 from fastapi import APIRouter, Query, Request, Response, status
-from sqlalchemy import select as sa_select
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
 from zndraw_socketio import AsyncServerWrapper
 
 from zndraw.dependencies import (
@@ -84,13 +84,13 @@ async def _find_frames_provider(
     session: AsyncSession, room_id: str
 ) -> ProviderRecord | None:
     """Find a frames provider registered for this room."""
-    result = await session.execute(
-        sa_select(ProviderRecord).where(
+    result = await session.exec(
+        select(ProviderRecord).where(
             ProviderRecord.room_id == room_id,
             ProviderRecord.category == "frames",
         )
     )
-    return result.scalar_one_or_none()
+    return result.one_or_none()
 
 
 async def _dispatch_provider_frame(

--- a/src/zndraw/routes/geometries.py
+++ b/src/zndraw/routes/geometries.py
@@ -104,10 +104,10 @@ async def list_geometries(
     await verify_room(session, room_id)
 
     # SQL geometries
-    result = await session.execute(
+    result = await session.exec(
         select(RoomGeometry).where(RoomGeometry.room_id == room_id)
     )
-    rows = result.scalars().all()
+    rows = result.all()
     geometries = {row.key: _row_to_geometry_data(row) for row in rows}
 
     # Merge Redis session cameras

--- a/src/zndraw/routes/presets.py
+++ b/src/zndraw/routes/presets.py
@@ -97,10 +97,10 @@ async def list_presets(
     DB presets override bundled ones with the same name.
     """
     await verify_room(session, room_id)
-    result = await session.execute(
+    result = await session.exec(
         select(RoomPreset).where(RoomPreset.room_id == room_id)
     )
-    rows = result.scalars().all()
+    rows = result.all()
 
     # Start with bundled, let DB rows override
     merged: dict[str, Preset] = dict(_bundled_presets())
@@ -257,7 +257,7 @@ async def apply_preset(
         from zndraw.routes.rooms import _initialize_default_geometries
 
         stmt = select(RoomGeometry).where(RoomGeometry.room_id == room_id)
-        existing = (await session.execute(stmt)).scalars().all()
+        existing = (await session.exec(stmt)).all()
         existing_keys = [g.key for g in existing]
         for g in existing:
             await session.delete(g)
@@ -266,7 +266,7 @@ async def apply_preset(
         await session.commit()
 
         new_stmt = select(RoomGeometry).where(RoomGeometry.room_id == room_id)
-        new_keys = [g.key for g in (await session.execute(new_stmt)).scalars().all()]
+        new_keys = [g.key for g in (await session.exec(new_stmt)).all()]
         all_keys = sorted(set(existing_keys) | set(new_keys))
         for key in all_keys:
             await sio.emit(
@@ -285,7 +285,7 @@ async def apply_preset(
         rules = bundled.rules
 
     stmt = select(RoomGeometry).where(RoomGeometry.room_id == room_id)
-    geometries = (await session.execute(stmt)).scalars().all()
+    geometries = (await session.exec(stmt)).all()
 
     updated_keys: list[str] = []
     for geom in geometries:

--- a/src/zndraw/routes/presets.py
+++ b/src/zndraw/routes/presets.py
@@ -97,9 +97,7 @@ async def list_presets(
     DB presets override bundled ones with the same name.
     """
     await verify_room(session, room_id)
-    result = await session.exec(
-        select(RoomPreset).where(RoomPreset.room_id == room_id)
-    )
+    result = await session.exec(select(RoomPreset).where(RoomPreset.room_id == room_id))
     rows = result.all()
 
     # Start with bundled, let DB rows override

--- a/src/zndraw/routes/rooms.py
+++ b/src/zndraw/routes/rooms.py
@@ -10,8 +10,8 @@ import re
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Query, status
-from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from zndraw.dependencies import (
     CurrentUserDep,
@@ -199,10 +199,10 @@ async def _copy_room_state(
     Rows are added to the session but NOT committed — caller must commit.
     """
     # Copy geometries (skip owned — ephemeral session cameras)
-    result = await session.execute(
+    result = await session.exec(
         select(RoomGeometry).where(RoomGeometry.room_id == source_room_id)
     )
-    for row in result.scalars().all():
+    for row in result.all():
         config = json.loads(row.config)
         if config.get("owner") is not None:
             continue
@@ -217,10 +217,10 @@ async def _copy_room_state(
         )
 
     # Copy bookmarks
-    result = await session.execute(
+    result = await session.exec(
         select(RoomBookmark).where(RoomBookmark.room_id == source_room_id)
     )
-    for row in result.scalars().all():
+    for row in result.all():
         session.add(
             RoomBookmark(
                 room_id=target_room_id,
@@ -230,10 +230,10 @@ async def _copy_room_state(
         )
 
     # Copy figures
-    result = await session.execute(
+    result = await session.exec(
         select(RoomFigure).where(RoomFigure.room_id == source_room_id)
     )
-    for row in result.scalars().all():
+    for row in result.all():
         session.add(
             RoomFigure(
                 room_id=target_room_id,
@@ -244,10 +244,10 @@ async def _copy_room_state(
         )
 
     # Copy selection groups
-    result = await session.execute(
+    result = await session.exec(
         select(SelectionGroup).where(SelectionGroup.room_id == source_room_id)
     )
-    for row in result.scalars().all():
+    for row in result.all():
         session.add(
             SelectionGroup(
                 room_id=target_room_id,
@@ -417,8 +417,8 @@ async def list_rooms(
 
     # Get all rooms (for PoC, show all public rooms)
     statement = select(Room).where(Room.is_public.is_(True))
-    result = await session.execute(statement)
-    rooms = list(result.scalars().all())
+    result = await session.exec(statement)
+    rooms = list(result.all())
 
     # Build response with frame counts
     room_responses = []

--- a/src/zndraw/routes/screenshots.py
+++ b/src/zndraw/routes/screenshots.py
@@ -237,15 +237,15 @@ async def list_screenshots(
         .offset(offset)
         .limit(limit)
     )
-    result = await session.execute(stmt)
-    rows = list(result.scalars().all())
+    result = await session.exec(stmt)
+    rows = list(result.all())
 
     count_stmt = (
         select(func.count())
         .select_from(Screenshot)
         .where(Screenshot.room_id == room_id, Screenshot.status == "completed")
     )
-    total = (await session.execute(count_stmt)).scalar_one()
+    total = (await session.exec(count_stmt)).one()
 
     items = [
         ScreenshotListItem(

--- a/src/zndraw/routes/selection_groups.py
+++ b/src/zndraw/routes/selection_groups.py
@@ -47,11 +47,11 @@ async def list_selection_groups(
 
     from sqlmodel import select
 
-    result = await session.execute(
+    result = await session.exec(
         select(SelectionGroup).where(SelectionGroup.room_id == room_id)
     )
     groups: dict[str, dict[str, list[int]]] = {}
-    for row in result.scalars().all():
+    for row in result.all():
         groups[row.name] = json.loads(row.selections)
 
     return SelectionGroupsListResponse(items=groups)

--- a/src/zndraw_auth/cli_login.py
+++ b/src/zndraw_auth/cli_login.py
@@ -9,7 +9,7 @@ from typing import Annotated
 
 import jwt as pyjwt
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
-from sqlalchemy import select
+from sqlmodel import select
 
 from zndraw_auth.db import CLILoginChallenge, SessionDep, User
 from zndraw_auth.schemas import CLILoginCreateResponse, CLILoginStatusResponse
@@ -65,10 +65,10 @@ async def poll_cli_login_challenge(
     """Poll a CLI login challenge status."""
     now = datetime.now(UTC).replace(tzinfo=None)
 
-    result = await session.execute(
+    result = await session.exec(
         select(CLILoginChallenge).where(CLILoginChallenge.code == code)
     )
-    challenge = result.scalar_one_or_none()
+    challenge = result.one_or_none()
 
     if challenge is None or challenge.secret != secret:
         raise HTTPException(status_code=404, detail="Challenge not found")
@@ -118,10 +118,10 @@ async def approve_cli_login_challenge(
     session: SessionDep,
 ) -> dict[str, str]:
     """Approve a CLI login challenge (browser user, auth required)."""
-    result = await session.execute(
+    result = await session.exec(
         select(CLILoginChallenge).where(CLILoginChallenge.code == code)
     )
-    challenge = result.scalar_one_or_none()
+    challenge = result.one_or_none()
 
     if challenge is None or challenge.status != "pending":
         raise HTTPException(status_code=404, detail="Challenge not found")
@@ -152,10 +152,10 @@ async def reject_cli_login_challenge(
     session: SessionDep,
 ) -> Response:
     """Reject a CLI login challenge (browser user, auth required)."""
-    result = await session.execute(
+    result = await session.exec(
         select(CLILoginChallenge).where(CLILoginChallenge.code == code)
     )
-    challenge = result.scalar_one_or_none()
+    challenge = result.one_or_none()
 
     if challenge is None:
         raise HTTPException(status_code=404, detail="Challenge not found")

--- a/src/zndraw_auth/db.py
+++ b/src/zndraw_auth/db.py
@@ -14,11 +14,10 @@ from sqlalchemy.ext.asyncio import (
     async_sessionmaker,
     create_async_engine,
 )
-from sqlmodel import select
-from sqlmodel.ext.asyncio.session import AsyncSession
 from sqlalchemy.orm import DeclarativeBase
 from sqlalchemy.pool import NullPool, StaticPool
-from sqlmodel import Field, SQLModel
+from sqlmodel import Field, SQLModel, select
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from zndraw_auth.settings import AuthSettings
 

--- a/src/zndraw_auth/db.py
+++ b/src/zndraw_auth/db.py
@@ -9,13 +9,13 @@ from typing import Annotated
 from fastapi import Depends, Request
 from fastapi_users.db import SQLAlchemyBaseUserTableUUID, SQLAlchemyUserDatabase
 from fastapi_users.password import PasswordHelper
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
-    AsyncSession,
     async_sessionmaker,
     create_async_engine,
 )
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
 from sqlalchemy.orm import DeclarativeBase
 from sqlalchemy.pool import NullPool, StaticPool
 from sqlmodel import Field, SQLModel
@@ -158,10 +158,10 @@ async def ensure_default_admin(
     password_helper = PasswordHelper()
 
     # Check if user exists
-    result = await session.execute(
+    result = await session.exec(
         select(User).where(User.email == settings.default_admin_email)  # type: ignore[arg-type]
     )
-    existing = result.scalar_one_or_none()
+    existing = result.one_or_none()
 
     if existing is None:
         # Create admin user

--- a/src/zndraw_joblib/dependencies.py
+++ b/src/zndraw_joblib/dependencies.py
@@ -150,10 +150,10 @@ async def get_worker_token(request: Request, session: SessionDep) -> str:
     """
     settings = request.app.state.settings
     auth_settings = request.app.state.auth_settings
-    result = await session.execute(
+    result = await session.exec(
         select(User).where(User.email == settings.internal_worker_email)  # type: ignore[arg-type]
     )
-    user = result.scalar_one_or_none()
+    user = result.one_or_none()
     if user is None:
         raise RuntimeError(
             f"Internal worker user '{settings.internal_worker_email}' not found. "

--- a/src/zndraw_joblib/registry.py
+++ b/src/zndraw_joblib/registry.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from contextlib import AbstractAsyncContextManager
 
     from fastapi import FastAPI
-    from sqlalchemy.ext.asyncio import AsyncSession
+    from sqlmodel.ext.asyncio.session import AsyncSession
     from taskiq import AsyncBroker
 
     from zndraw_joblib.client import Extension
@@ -95,7 +95,7 @@ async def ensure_internal_jobs(
     replicas, call once from ``init_database()`` / ``zndraw-db`` to avoid
     race conditions on the ``unique_job`` constraint.
     """
-    from sqlalchemy import select
+    from sqlmodel import select
 
     from zndraw_joblib.models import Job
 
@@ -105,14 +105,14 @@ async def ensure_internal_jobs(
             name = ext_cls.__name__
             schema = ext_cls.model_json_schema()
 
-            result = await session.execute(
+            result = await session.exec(
                 select(Job).where(
                     Job.room_id == "@internal",
                     Job.category == category,
                     Job.name == name,
                 )
             )
-            existing = result.scalar_one_or_none()
+            existing = result.one_or_none()
 
             if existing and existing.deleted:
                 existing.deleted = False

--- a/src/zndraw_joblib/router.py
+++ b/src/zndraw_joblib/router.py
@@ -8,10 +8,12 @@ from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Header, Query, Request, Response, status
-from sqlalchemy import func, select, update
+from sqlalchemy import func, update
 from sqlalchemy.exc import OperationalError
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlalchemy.ext.asyncio import async_sessionmaker
 from sqlalchemy.orm import selectinload
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
 from zndraw_socketio import AsyncServerWrapper
 
 from zndraw_auth import (
@@ -134,22 +136,22 @@ async def _resolve_job(session: AsyncSession, job_name: str) -> Job:
         raise JobNotFound.exception(detail=f"Invalid job name format: {job_name}")
     job_room_id, category, name = parts
 
-    result = await session.execute(
+    result = await session.exec(
         select(Job).where(
             Job.room_id == job_room_id,
             Job.category == category,
             Job.name == name,
         )
     )
-    job = result.scalar_one_or_none()
+    job = result.one_or_none()
     if not job or job.deleted:
         raise JobNotFound.exception(detail=f"Job '{job_name}' not found")
     return job
 
 
 async def _task_response(session: AsyncSession, task: Task) -> TaskResponse:
-    result = await session.execute(select(Job).where(Job.id == task.job_id))
-    job = result.scalar_one_or_none()
+    result = await session.exec(select(Job).where(Job.id == task.job_id))
+    job = result.one_or_none()
     return TaskResponse(
         id=task.id,
         job_name=job.full_name if job else "",
@@ -181,7 +183,7 @@ async def _bulk_queue_positions(
         .label("pos")
     )
     subq = select(Task.id, row_num).where(Task.status == TaskStatus.PENDING).subquery()
-    result = await session.execute(
+    result = await session.exec(
         select(subq.c.id, subq.c.pos).where(subq.c.id.in_(task_ids))
     )
     return {row.id: row.pos for row in result}
@@ -220,8 +222,8 @@ async def _task_status_emission(session: AsyncSession, task: Task) -> Emission:
 
     Queries job name and queue position.
     """
-    result = await session.execute(select(Job).where(Job.id == task.job_id))
-    job = result.scalar_one_or_none()
+    result = await session.exec(select(Job).where(Job.id == task.job_id))
+    job = result.one_or_none()
     return build_task_status_emission(
         task,
         job_full_name=job.full_name if job else "",
@@ -291,14 +293,14 @@ async def register_job(
         )
 
     # Check if job exists
-    result = await session.execute(
+    result = await session.exec(
         select(Job).where(
             Job.room_id == room_id,
             Job.category == request.category,
             Job.name == request.name,
         )
     )
-    existing_job = result.scalar_one_or_none()
+    existing_job = result.one_or_none()
 
     if existing_job and existing_job.deleted:
         # Re-activate soft-deleted job with new schema
@@ -328,13 +330,13 @@ async def register_job(
     # Handle worker: use provided worker_id or auto-create
     if request.worker_id:
         # Verify ownership
-        result = await session.execute(
+        result = await session.exec(
             select(Worker).where(
                 Worker.id == request.worker_id,
                 Worker.user_id == user.id,
             )
         )
-        worker = result.scalar_one_or_none()
+        worker = result.one_or_none()
         if not worker:
             raise WorkerNotFound.exception(
                 detail=f"Worker '{request.worker_id}' not found or not owned by user"
@@ -346,13 +348,13 @@ async def register_job(
         await session.flush()
 
     # Ensure worker-job link exists
-    result = await session.execute(
+    result = await session.exec(
         select(WorkerJobLink).where(
             WorkerJobLink.worker_id == worker.id,
             WorkerJobLink.job_id == job.id,
         )
     )
-    link = result.scalar_one_or_none()
+    link = result.one_or_none()
     if not link:
         link = WorkerJobLink(worker_id=worker.id, job_id=job.id)
         session.add(link)
@@ -362,10 +364,10 @@ async def register_job(
     await session.refresh(job)
 
     # Get worker IDs for this job
-    result = await session.execute(
+    result = await session.exec(
         select(WorkerJobLink).where(WorkerJobLink.job_id == job.id)
     )
-    worker_links = result.scalars().all()
+    worker_links = result.all()
     worker_ids = [link.worker_id for link in worker_links]
 
     return JobResponse(
@@ -393,19 +395,19 @@ async def list_jobs(
     base_query = select(Job).where(_room_job_filter(room_id), Job.deleted.is_(False))
 
     # Total count
-    total_result = await session.execute(
+    total_result = await session.exec(
         select(func.count()).select_from(base_query.subquery())
     )
-    total = total_result.scalar()
+    total = total_result.one()
 
     # Paginated + eager-load workers
-    result = await session.execute(
+    result = await session.exec(
         base_query.options(selectinload(Job.workers))
         .order_by(Job.created_at.desc())
         .offset(offset)
         .limit(limit)
     )
-    jobs = result.scalars().all()
+    jobs = result.all()
 
     items = [
         JobSummary(
@@ -429,10 +431,10 @@ async def list_workers_for_room(
     """List workers for a room. Includes @global workers unless room_id is @global."""
     validate_room_id(room_id)
 
-    result = await session.execute(
+    result = await session.exec(
         select(Job.id).where(_room_job_filter(room_id), Job.deleted.is_(False))
     )
-    job_ids = result.scalars().all()
+    job_ids = result.all()
 
     if not job_ids:
         return PaginatedResponse(items=[], total=0, limit=limit, offset=offset)
@@ -445,13 +447,13 @@ async def list_workers_for_room(
     )
 
     # Total count
-    total_result = await session.execute(
+    total_result = await session.exec(
         select(func.count()).select_from(worker_id_query.subquery())
     )
-    total = total_result.scalar()
+    total = total_result.one()
 
     # Paginated workers with eager-loaded jobs
-    result = await session.execute(
+    result = await session.exec(
         select(Worker)
         .where(Worker.id.in_(worker_id_query))
         .options(selectinload(Worker.jobs))
@@ -459,7 +461,7 @@ async def list_workers_for_room(
         .offset(offset)
         .limit(limit)
     )
-    workers = result.scalars().all()
+    workers = result.all()
 
     items = [
         WorkerSummary(
@@ -491,19 +493,19 @@ async def list_tasks_for_room(
         base_query = base_query.where(Task.status == task_status)
 
     # Total count
-    total_result = await session.execute(
+    total_result = await session.exec(
         select(func.count()).select_from(base_query.subquery())
     )
-    total = total_result.scalar()
+    total = total_result.one()
 
     # Paginated + eager-load job relationship
-    result = await session.execute(
+    result = await session.exec(
         base_query.options(selectinload(Task.job))
         .order_by(Task.created_at.desc())
         .offset(offset)
         .limit(limit)
     )
-    tasks = result.scalars().all()
+    tasks = result.all()
 
     items = await _bulk_task_responses(session, tasks)
     return PaginatedResponse(items=items, total=total, limit=limit, offset=offset)
@@ -531,19 +533,19 @@ async def list_tasks_for_job(
         base_query = base_query.where(Task.status == task_status)
 
     # Total count
-    total_result = await session.execute(
+    total_result = await session.exec(
         select(func.count()).select_from(base_query.subquery())
     )
-    total = total_result.scalar()
+    total = total_result.one()
 
     # Paginated + eager-load job relationship
-    result = await session.execute(
+    result = await session.exec(
         base_query.options(selectinload(Task.job))
         .order_by(Task.created_at.desc())
         .offset(offset)
         .limit(limit)
     )
-    tasks = result.scalars().all()
+    tasks = result.all()
 
     items = await _bulk_task_responses(session, tasks)
     return PaginatedResponse(items=items, total=total, limit=limit, offset=offset)
@@ -560,10 +562,10 @@ async def get_job(
 
     job = await _resolve_job(session, job_name)
 
-    result = await session.execute(
+    result = await session.exec(
         select(WorkerJobLink).where(WorkerJobLink.job_id == job.id)
     )
-    worker_links = result.scalars().all()
+    worker_links = result.all()
     worker_ids = [link.worker_id for link in worker_links]
 
     return JobResponse(
@@ -610,10 +612,10 @@ async def submit_task(
     # Reject submission for non-@internal jobs with no connected workers
     if job.room_id != "@internal":
         worker_count = (
-            await session.execute(
+            await session.exec(
                 select(func.count()).where(WorkerJobLink.job_id == job.id)
             )
-        ).scalar_one()
+        ).one()
         if worker_count == 0:
             raise NoWorkersAvailable.exception(
                 detail=f"Job '{job.full_name}' has no connected workers"
@@ -684,8 +686,8 @@ async def claim_task(
 ):
     """Claim the oldest pending task for jobs the specified worker is registered for."""
     # Validate that worker_id exists and belongs to the authenticated user
-    result = await session.execute(select(Worker).where(Worker.id == request.worker_id))
-    worker = result.scalar_one_or_none()
+    result = await session.exec(select(Worker).where(Worker.id == request.worker_id))
+    worker = result.one_or_none()
 
     if not worker:
         raise WorkerNotFound.exception(f"Worker {request.worker_id} not found")
@@ -694,10 +696,10 @@ async def claim_task(
         raise Forbidden.exception("Worker belongs to a different user")
 
     # Find job IDs for this specific worker
-    result = await session.execute(
+    result = await session.exec(
         select(WorkerJobLink.job_id).where(WorkerJobLink.worker_id == request.worker_id)
     )
-    worker_job_ids = result.scalars().all()
+    worker_job_ids = result.all()
 
     if not worker_job_ids:
         return TaskClaimResponse(task=None)
@@ -711,7 +713,7 @@ async def claim_task(
     for attempt in range(max_attempts):
         try:
             # Find oldest pending task for jobs this worker is registered for
-            result = await session.execute(
+            result = await session.exec(
                 select(Task.id)
                 .where(
                     Task.job_id.in_(worker_job_ids), Task.status == TaskStatus.PENDING
@@ -719,7 +721,7 @@ async def claim_task(
                 .order_by(Task.created_at.asc())
                 .limit(1)
             )
-            task_id = result.scalar_one_or_none()
+            task_id = result.one_or_none()
 
             if not task_id:
                 return TaskClaimResponse(task=None)
@@ -730,7 +732,7 @@ async def claim_task(
                 .where(Task.id == task_id, Task.status == TaskStatus.PENDING)
                 .values(status=TaskStatus.CLAIMED, worker_id=request.worker_id)
             )
-            cursor_result = await session.execute(stmt)
+            cursor_result = await session.exec(stmt)
             await session.commit()
 
             # Check if we actually claimed it (rowcount == 1 means success)
@@ -762,8 +764,8 @@ async def claim_task(
         return TaskClaimResponse(task=None)
 
     # Fetch the claimed task
-    result = await session.execute(select(Task).where(Task.id == claimed_task_id))
-    task = result.scalar_one()
+    result = await session.exec(select(Task).where(Task.id == claimed_task_id))
+    task = result.one()
 
     await emit(tsio, {await _task_status_emission(session, task)})
 
@@ -781,8 +783,8 @@ async def get_task_status(
     """Get task status. Supports long-polling via Prefer: wait=N header."""
     # Initial lookup
     async with session_maker() as session:
-        result = await session.execute(select(Task).where(Task.id == task_id))
-        task = result.scalar_one_or_none()
+        result = await session.exec(select(Task).where(Task.id == task_id))
+        task = result.one_or_none()
         if not task:
             raise TaskNotFound.exception(detail=f"Task '{task_id}' not found")
 
@@ -802,8 +804,8 @@ async def get_task_status(
             )  # Exponential backoff, cap at 5s
 
             async with session_maker() as session:
-                result = await session.execute(select(Task).where(Task.id == task_id))
-                task = result.scalar_one_or_none()
+                result = await session.exec(select(Task).where(Task.id == task_id))
+                task = result.one_or_none()
                 if not task:
                     raise TaskNotFound.exception(detail=f"Task '{task_id}' not found")
 
@@ -811,8 +813,8 @@ async def get_task_status(
 
     # Build final response — re-fetch to avoid stale detached object
     async with session_maker() as session:
-        result = await session.execute(select(Task).where(Task.id == task_id))
-        task = result.scalar_one()
+        result = await session.exec(select(Task).where(Task.id == task_id))
+        task = result.one()
         return await _task_response(session, task)
 
 
@@ -825,8 +827,8 @@ async def update_task_status(
     tsio: TsioDep,
 ):
     """Update task status. Requires the task's worker owner or superuser."""
-    result = await session.execute(select(Task).where(Task.id == task_id))
-    task = result.scalar_one_or_none()
+    result = await session.exec(select(Task).where(Task.id == task_id))
+    task = result.one_or_none()
     if not task:
         raise TaskNotFound.exception(detail=f"Task '{task_id}' not found")
 
@@ -834,10 +836,10 @@ async def update_task_status(
     if not user.is_superuser:
         if task.worker_id is None:
             raise Forbidden.exception(detail="Task not claimed by any worker")
-        result = await session.execute(
+        result = await session.exec(
             select(Worker).where(Worker.id == task.worker_id)
         )
-        worker = result.scalar_one_or_none()
+        worker = result.one_or_none()
         if not worker or worker.user_id != user.id:
             raise Forbidden.exception(detail="Not authorized to update this task")
 
@@ -888,18 +890,18 @@ async def list_workers(
 ):
     """List all workers with their job counts."""
     # Total count
-    total_result = await session.execute(select(func.count()).select_from(Worker))
-    total = total_result.scalar()
+    total_result = await session.exec(select(func.count()).select_from(Worker))
+    total = total_result.one()
 
     # Paginated + eager-load jobs
-    result = await session.execute(
+    result = await session.exec(
         select(Worker)
         .options(selectinload(Worker.jobs))
         .order_by(Worker.created_at.desc())
         .offset(offset)
         .limit(limit)
     )
-    workers = result.scalars().all()
+    workers = result.all()
 
     items = [
         WorkerSummary(
@@ -919,8 +921,8 @@ async def worker_heartbeat(
     user: CurrentUserDep,
 ):
     """Update worker heartbeat. Worker must belong to authenticated user."""
-    result = await session.execute(select(Worker).where(Worker.id == worker_id))
-    worker = result.scalar_one_or_none()
+    result = await session.exec(select(Worker).where(Worker.id == worker_id))
+    worker = result.one_or_none()
     if not worker:
         raise WorkerNotFound.exception(detail=f"Worker '{worker_id}' not found")
 
@@ -947,8 +949,8 @@ async def delete_worker(
 
     Worker must belong to authenticated user or user must be superuser.
     """
-    result = await session.execute(select(Worker).where(Worker.id == worker_id))
-    worker = result.scalar_one_or_none()
+    result = await session.exec(select(Worker).where(Worker.id == worker_id))
+    worker = result.one_or_none()
     if not worker:
         raise WorkerNotFound.exception(detail=f"Worker '{worker_id}' not found")
 
@@ -994,14 +996,14 @@ async def _resolve_provider(
             detail=f"Provider '{provider_name}' not accessible from room '{room_id}'"
         )
 
-    result = await session.execute(
+    result = await session.exec(
         select(ProviderRecord).where(
             ProviderRecord.room_id == provider_room_id,
             ProviderRecord.category == category,
             ProviderRecord.name == name,
         )
     )
-    provider = result.scalar_one_or_none()
+    provider = result.one_or_none()
     if not provider:
         raise ProviderNotFound.exception(detail=f"Provider '{provider_name}' not found")
     return provider
@@ -1040,13 +1042,13 @@ async def register_provider(
 
     # Handle worker: use provided worker_id or auto-create
     if request.worker_id:
-        result = await session.execute(
+        result = await session.exec(
             select(Worker).where(
                 Worker.id == request.worker_id,
                 Worker.user_id == user.id,
             )
         )
-        worker = result.scalar_one_or_none()
+        worker = result.one_or_none()
         if not worker:
             raise WorkerNotFound.exception(
                 detail=f"Worker '{request.worker_id}' not found or not owned by user"
@@ -1057,14 +1059,14 @@ async def register_provider(
         await session.flush()
 
     # Check if provider already exists (upsert)
-    result = await session.execute(
+    result = await session.exec(
         select(ProviderRecord).where(
             ProviderRecord.category == request.category,
             ProviderRecord.name == request.name,
             ProviderRecord.room_id == room_id,
         )
     )
-    existing = result.scalar_one_or_none()
+    existing = result.one_or_none()
 
     if existing:
         if existing.user_id != user.id and not user.is_superuser:
@@ -1111,17 +1113,17 @@ async def list_providers(
 
     base_query = select(ProviderRecord).where(_room_provider_filter(room_id))
 
-    total_result = await session.execute(
+    total_result = await session.exec(
         select(func.count()).select_from(base_query.subquery())
     )
-    total = total_result.scalar()
+    total = total_result.one()
 
-    result = await session.execute(
+    result = await session.exec(
         base_query.order_by(ProviderRecord.created_at.desc())
         .offset(offset)
         .limit(limit)
     )
-    providers = result.scalars().all()
+    providers = result.all()
 
     items = [ProviderResponse.from_record(p) for p in providers]
     return PaginatedResponse(items=items, total=total, limit=limit, offset=offset)
@@ -1223,10 +1225,10 @@ async def delete_provider(
     tsio: TsioDep,
 ):
     """Unregister a provider. Must be owned by authenticated user or superuser."""
-    result = await session.execute(
+    result = await session.exec(
         select(ProviderRecord).where(ProviderRecord.id == provider_id)
     )
-    provider = result.scalar_one_or_none()
+    provider = result.one_or_none()
     if not provider:
         raise ProviderNotFound.exception(detail=f"Provider '{provider_id}' not found")
 
@@ -1255,10 +1257,10 @@ async def upload_provider_result(
 ):
     """Provider worker uploads a read result."""
     async with session_maker() as session:
-        result = await session.execute(
+        result = await session.exec(
             select(ProviderRecord).where(ProviderRecord.id == provider_id)
         )
-        provider = result.scalar_one_or_none()
+        provider = result.one_or_none()
         if not provider:
             raise ProviderNotFound.exception(
                 detail=f"Provider '{provider_id}' not found"

--- a/src/zndraw_joblib/router.py
+++ b/src/zndraw_joblib/router.py
@@ -836,9 +836,7 @@ async def update_task_status(
     if not user.is_superuser:
         if task.worker_id is None:
             raise Forbidden.exception(detail="Task not claimed by any worker")
-        result = await session.exec(
-            select(Worker).where(Worker.id == task.worker_id)
-        )
+        result = await session.exec(select(Worker).where(Worker.id == task.worker_id))
         worker = result.one_or_none()
         if not worker or worker.user_id != user.id:
             raise Forbidden.exception(detail="Not authorized to update this task")

--- a/src/zndraw_joblib/sweeper.py
+++ b/src/zndraw_joblib/sweeper.py
@@ -8,9 +8,10 @@ from collections.abc import AsyncGenerator, Callable
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from sqlalchemy import func as sa_func, select
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import func as sa_func
 from sqlalchemy.orm import selectinload
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
 from zndraw_socketio import AsyncServerWrapper
 
 from zndraw_joblib.events import (
@@ -46,20 +47,20 @@ async def _soft_delete_orphan_job(
     Note: Does NOT commit the transaction - caller must commit.
     """
     # @internal jobs are never orphaned — they're registered at startup
-    result = await session.execute(select(Job).where(Job.id == job_id))
-    job = result.scalar_one_or_none()
+    result = await session.exec(select(Job).where(Job.id == job_id))
+    job = result.one_or_none()
     if not job or job.room_id == "@internal":
         return set()
 
     # Check if job has any remaining workers
-    result = await session.execute(
+    result = await session.exec(
         select(WorkerJobLink).where(WorkerJobLink.job_id == job_id).limit(1)
     )
-    if result.scalar_one_or_none():
+    if result.one_or_none():
         return set()  # Job still has workers
 
     # Check if job has any pending tasks (new workers could register and pick them up)
-    result = await session.execute(
+    result = await session.exec(
         select(Task)
         .where(
             Task.job_id == job_id,
@@ -67,7 +68,7 @@ async def _soft_delete_orphan_job(
         )
         .limit(1)
     )
-    if result.scalar_one_or_none():
+    if result.one_or_none():
         return set()  # Job has pending tasks, keep it alive
 
     emissions: set[Emission] = set()
@@ -97,7 +98,7 @@ async def cleanup_worker(
     now = datetime.now(UTC)
 
     # Fail any claimed/running tasks owned by this worker
-    result = await session.execute(
+    result = await session.exec(
         select(Task)
         .options(selectinload(Task.job))
         .where(
@@ -105,7 +106,7 @@ async def cleanup_worker(
             Task.status.in_({TaskStatus.CLAIMED, TaskStatus.RUNNING}),
         )
     )
-    worker_tasks = result.scalars().all()
+    worker_tasks = result.all()
     for task in worker_tasks:
         task.status = TaskStatus.FAILED
         task.completed_at = now
@@ -116,15 +117,15 @@ async def cleanup_worker(
         )
 
     # Get links this worker has (need both job_ids and the link objects)
-    result = await session.execute(
+    result = await session.exec(
         select(WorkerJobLink).where(WorkerJobLink.worker_id == worker.id)
     )
-    links = result.scalars().all()
+    links = result.all()
     job_ids = [link.job_id for link in links]
 
     # Fetch room_ids for affected jobs (worker count is changing)
     if job_ids:
-        result = await session.execute(
+        result = await session.exec(
             select(Job.id, Job.room_id).where(Job.id.in_(job_ids))
         )
         job_rooms = {row.id: row.room_id for row in result.all()}
@@ -136,10 +137,10 @@ async def cleanup_worker(
         emissions.add(Emission(JobsInvalidate(), f"room:{room_id}"))
 
     # Delete providers owned by this worker
-    result = await session.execute(
+    result = await session.exec(
         select(ProviderRecord).where(ProviderRecord.worker_id == worker.id)
     )
-    providers = result.scalars().all()
+    providers = result.all()
     provider_rooms: set[str] = set()
     frame_provider_rooms: set[str] = set()
     for provider in providers:
@@ -188,8 +189,8 @@ async def cleanup_stale_workers(
     all_frame_rooms: set[str] = set()
 
     # Find all stale workers
-    result = await session.execute(select(Worker).where(Worker.last_heartbeat < cutoff))
-    stale_workers = result.scalars().all()
+    result = await session.exec(select(Worker).where(Worker.last_heartbeat < cutoff))
+    stale_workers = result.all()
 
     count = 0
     for worker in stale_workers:
@@ -226,7 +227,7 @@ async def cleanup_stuck_internal_tasks(
     now = datetime.now(UTC)
     emissions: set[Emission] = set()
 
-    result = await session.execute(
+    result = await session.exec(
         select(Task)
         .join(Job)
         .options(selectinload(Task.job))
@@ -236,7 +237,7 @@ async def cleanup_stuck_internal_tasks(
             sa_func.coalesce(Task.started_at, Task.created_at) < cutoff,
         )
     )
-    stuck_tasks = result.scalars().all()
+    stuck_tasks = result.all()
 
     count = 0
     for task in stuck_tasks:

--- a/tests/zndraw/conftest.py
+++ b/tests/zndraw/conftest.py
@@ -14,7 +14,8 @@ import pytest_asyncio
 import uvicorn
 from helpers import InMemoryResultBackend, MockSioServer, create_test_user_model
 from httpx import ASGITransport, AsyncClient
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel.ext.asyncio.session import AsyncSession
 from sqlalchemy.pool import StaticPool
 from sqlmodel import SQLModel
 

--- a/tests/zndraw/conftest.py
+++ b/tests/zndraw/conftest.py
@@ -15,9 +15,9 @@ import uvicorn
 from helpers import InMemoryResultBackend, MockSioServer, create_test_user_model
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
-from sqlmodel.ext.asyncio.session import AsyncSession
 from sqlalchemy.pool import StaticPool
 from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from zndraw.config import Settings
 from zndraw.storage import FrameStorage

--- a/tests/zndraw_auth/conftest.py
+++ b/tests/zndraw_auth/conftest.py
@@ -9,8 +9,8 @@ from httpx import ASGITransport, AsyncClient
 from pydantic import BaseModel
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
-from sqlmodel.ext.asyncio.session import AsyncSession
 from sqlalchemy.pool import StaticPool
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from zndraw_auth import (
     SessionDep,
@@ -101,7 +101,9 @@ async def _create_test_app(
         connect_args={"check_same_thread": False},
         poolclass=StaticPool,
     )
-    test_session_maker = async_sessionmaker(test_engine, class_=AsyncSession, expire_on_commit=False)
+    test_session_maker = async_sessionmaker(
+        test_engine, class_=AsyncSession, expire_on_commit=False
+    )
 
     app = FastAPI()
 

--- a/tests/zndraw_auth/conftest.py
+++ b/tests/zndraw_auth/conftest.py
@@ -9,6 +9,7 @@ from httpx import ASGITransport, AsyncClient
 from pydantic import BaseModel
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel.ext.asyncio.session import AsyncSession
 from sqlalchemy.pool import StaticPool
 
 from zndraw_auth import (
@@ -100,7 +101,7 @@ async def _create_test_app(
         connect_args={"check_same_thread": False},
         poolclass=StaticPool,
     )
-    test_session_maker = async_sessionmaker(test_engine, expire_on_commit=False)
+    test_session_maker = async_sessionmaker(test_engine, class_=AsyncSession, expire_on_commit=False)
 
     app = FastAPI()
 
@@ -166,7 +167,8 @@ async def _create_test_app(
         session: SessionDep,
     ) -> dict[str, str]:
         """Route using async session dependency."""
-        result = await session.execute(text("SELECT 1"))
+        conn = await session.connection()
+        result = await conn.execute(text("SELECT 1"))
         value = result.scalar()
         return {"db_check": str(value)}
 

--- a/tests/zndraw_joblib/conftest.py
+++ b/tests/zndraw_joblib/conftest.py
@@ -12,7 +12,8 @@ import httpx
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel.ext.asyncio.session import AsyncSession
 from sqlalchemy.pool import StaticPool
 
 from zndraw_auth import Base, User

--- a/tests/zndraw_joblib/conftest.py
+++ b/tests/zndraw_joblib/conftest.py
@@ -13,8 +13,8 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
-from sqlmodel.ext.asyncio.session import AsyncSession
 from sqlalchemy.pool import StaticPool
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from zndraw_auth import Base, User
 from zndraw_joblib.dependencies import get_result_backend

--- a/tests/zndraw_joblib/test_registry.py
+++ b/tests/zndraw_joblib/test_registry.py
@@ -3,7 +3,7 @@
 from typing import Any, ClassVar
 from unittest.mock import AsyncMock, MagicMock
 
-from sqlalchemy import select
+from sqlmodel import select
 
 from zndraw_joblib.client import Category, Extension
 from zndraw_joblib.models import Job
@@ -112,8 +112,8 @@ async def test_register_internal_jobs_creates_db_rows(async_session_factory):
     )
 
     async with async_session_factory() as session:
-        result = await session.execute(select(Job).where(Job.room_id == "@internal"))
-        jobs = result.scalars().all()
+        result = await session.exec(select(Job).where(Job.room_id == "@internal"))
+        jobs = result.all()
 
     assert len(jobs) == 2
     names = {j.full_name for j in jobs}
@@ -169,8 +169,8 @@ async def test_register_internal_jobs_reactivates_deleted(async_session_factory)
     )
 
     async with async_session_factory() as session:
-        result = await session.execute(
+        result = await session.exec(
             select(Job).where(Job.room_id == "@internal", Job.name == "Rotate")
         )
-        job = result.scalar_one()
+        job = result.one()
         assert not job.deleted

--- a/tests/zndraw_joblib/test_sweeper.py
+++ b/tests/zndraw_joblib/test_sweeper.py
@@ -41,9 +41,7 @@ async def test_cleanup_stale_workers_finds_stale(async_session_factory, test_use
 
     # Verify worker was deleted
     async with async_session_factory() as session:
-        result = await session.exec(
-            select(Worker).where(Worker.id == stale_worker_id)
-        )
+        result = await session.exec(select(Worker).where(Worker.id == stale_worker_id))
         worker = result.one_or_none()
         assert worker is None
 
@@ -70,9 +68,7 @@ async def test_cleanup_stale_workers_ignores_alive(async_session_factory, test_u
 
     # Verify worker still exists
     async with async_session_factory() as session:
-        result = await session.exec(
-            select(Worker).where(Worker.id == alive_worker_id)
-        )
+        result = await session.exec(select(Worker).where(Worker.id == alive_worker_id))
         worker = result.one_or_none()
         assert worker is not None
 

--- a/tests/zndraw_joblib/test_sweeper.py
+++ b/tests/zndraw_joblib/test_sweeper.py
@@ -7,7 +7,7 @@ import uuid
 from datetime import UTC, datetime, timedelta
 
 import pytest
-from sqlalchemy import select
+from sqlmodel import select
 
 from zndraw_joblib.events import JobsInvalidate, TaskStatusEvent
 from zndraw_joblib.models import Job, Task, TaskStatus, Worker, WorkerJobLink
@@ -41,10 +41,10 @@ async def test_cleanup_stale_workers_finds_stale(async_session_factory, test_use
 
     # Verify worker was deleted
     async with async_session_factory() as session:
-        result = await session.execute(
+        result = await session.exec(
             select(Worker).where(Worker.id == stale_worker_id)
         )
-        worker = result.scalar_one_or_none()
+        worker = result.one_or_none()
         assert worker is None
 
 
@@ -70,10 +70,10 @@ async def test_cleanup_stale_workers_ignores_alive(async_session_factory, test_u
 
     # Verify worker still exists
     async with async_session_factory() as session:
-        result = await session.execute(
+        result = await session.exec(
             select(Worker).where(Worker.id == alive_worker_id)
         )
-        worker = result.scalar_one_or_none()
+        worker = result.one_or_none()
         assert worker is not None
 
 
@@ -132,12 +132,12 @@ async def test_cleanup_fails_running_tasks(async_session_factory, test_user_id):
 
     # Verify CLAIMED and RUNNING tasks are failed, PENDING is unchanged
     async with async_session_factory() as session:
-        result = await session.execute(select(Task).where(Task.id == task_claimed_id))
-        claimed = result.scalar_one_or_none()
-        result = await session.execute(select(Task).where(Task.id == task_running_id))
-        running = result.scalar_one_or_none()
-        result = await session.execute(select(Task).where(Task.id == task_pending_id))
-        pending = result.scalar_one_or_none()
+        result = await session.exec(select(Task).where(Task.id == task_claimed_id))
+        claimed = result.one_or_none()
+        result = await session.exec(select(Task).where(Task.id == task_running_id))
+        running = result.one_or_none()
+        result = await session.exec(select(Task).where(Task.id == task_pending_id))
+        pending = result.one_or_none()
 
         assert claimed.status == TaskStatus.FAILED
         assert claimed.error == "Worker disconnected"
@@ -191,8 +191,8 @@ async def test_cleanup_soft_deletes_orphan_jobs(async_session_factory, test_user
 
     # Verify job is soft-deleted
     async with async_session_factory() as session:
-        result = await session.execute(select(Job).where(Job.id == job_id))
-        job = result.scalar_one_or_none()
+        result = await session.exec(select(Job).where(Job.id == job_id))
+        job = result.one_or_none()
         assert job is not None
         assert job.deleted is True
 
@@ -239,8 +239,8 @@ async def test_cleanup_keeps_job_with_pending_tasks(
 
     # Verify job is NOT soft-deleted because it has a pending task
     async with async_session_factory() as session:
-        result = await session.execute(select(Job).where(Job.id == job_id))
-        job = result.scalar_one_or_none()
+        result = await session.exec(select(Job).where(Job.id == job_id))
+        job = result.one_or_none()
         assert job is not None
         assert job.deleted is False
 
@@ -272,8 +272,8 @@ async def test_cleanup_multiple_stale_workers(async_session_factory, test_user_i
 
     # Verify only alive worker remains
     async with async_session_factory() as session:
-        result = await session.execute(select(Worker))
-        workers = result.scalars().all()
+        result = await session.exec(select(Worker))
+        workers = result.all()
         assert len(workers) == 1
         assert workers[0].id == alive_id
 
@@ -301,17 +301,17 @@ async def test_cleanup_worker_removes_links(async_session_factory, test_user_id)
         await session.commit()
 
         # Now cleanup
-        result = await session.execute(select(Worker).where(Worker.id == worker_id))
-        worker = result.scalar_one_or_none()
+        result = await session.exec(select(Worker).where(Worker.id == worker_id))
+        worker = result.one_or_none()
         await cleanup_worker(session, worker)
         await session.commit()
 
     # Verify link is removed
     async with async_session_factory() as session:
-        result = await session.execute(
+        result = await session.exec(
             select(WorkerJobLink).where(WorkerJobLink.worker_id == worker_id)
         )
-        links = result.scalars().all()
+        links = result.all()
         assert len(links) == 0
 
 
@@ -352,16 +352,16 @@ async def test_cleanup_job_keeps_other_workers(async_session_factory, test_user_
 
     # Verify job is NOT soft-deleted because alive-worker is still linked
     async with async_session_factory() as session:
-        result = await session.execute(select(Job).where(Job.id == job_id))
-        job = result.scalar_one_or_none()
+        result = await session.exec(select(Job).where(Job.id == job_id))
+        job = result.one_or_none()
         assert job is not None
         assert job.deleted is False
 
         # Verify alive worker's link still exists
-        result = await session.execute(
+        result = await session.exec(
             select(WorkerJobLink).where(WorkerJobLink.worker_id == alive_worker_id)
         )
-        link = result.scalar_one_or_none()
+        link = result.one_or_none()
         assert link is not None
 
 
@@ -390,8 +390,8 @@ async def test_cleanup_stuck_internal_tasks(async_session_factory):
         assert count == 1
 
     async with async_session_factory() as session:
-        result = await session.execute(select(Task).where(Task.id == task_id))
-        task = result.scalar_one()
+        result = await session.exec(select(Task).where(Task.id == task_id))
+        task = result.one()
         assert task.status == TaskStatus.FAILED
         assert task.error == "Internal worker timeout"
         assert task.completed_at is not None
@@ -475,8 +475,8 @@ async def test_cleanup_worker_returns_task_status_emissions(
         task_id = task.id
 
     async with async_session_factory() as session:
-        result = await session.execute(select(Worker).where(Worker.id == worker_id))
-        worker = result.scalar_one()
+        result = await session.exec(select(Worker).where(Worker.id == worker_id))
+        worker = result.one()
         emissions, _frame_rooms = await cleanup_worker(session, worker)
         await session.commit()
 
@@ -578,10 +578,10 @@ async def test_run_sweeper_cleans_up_stale_workers(async_session_factory, test_u
 
         # Verify the stale worker was cleaned up
         async with async_session_factory() as session:
-            result = await session.execute(
+            result = await session.exec(
                 select(Worker).where(Worker.id == stale_worker_id)
             )
-            worker = result.scalar_one_or_none()
+            worker = result.one_or_none()
             assert worker is None, "Stale worker should have been cleaned up"
 
     finally:
@@ -617,8 +617,8 @@ async def test_cleanup_stuck_internal_tasks_includes_claimed(async_session_facto
         assert count == 1
 
     async with async_session_factory() as session:
-        result = await session.execute(select(Task).where(Task.id == task_id))
-        task = result.scalar_one()
+        result = await session.exec(select(Task).where(Task.id == task_id))
+        task = result.one()
         assert task.status == TaskStatus.FAILED
         assert task.error == "Internal worker timeout"
         assert task.completed_at is not None


### PR DESCRIPTION
## Summary

- Migrate all 77 `session.execute()` call sites across 17 files in `src/` to SQLModel's `session.exec()` API — the SOTA recommendation per sqlmodel.tiangolo.com
- Eliminates 15,000+ `DeprecationWarning` instances per test run that were drowning out real warnings in CI
- Adds a `pyproject.toml` `filterwarnings` gate that escalates any future `session.execute()` reintroduction (on a SQLModel session) to a hard CI failure
- Updates `AsyncSession` imports from `sqlalchemy.ext.asyncio` to `sqlmodel.ext.asyncio.session` in files that use `.exec()`, so type annotations match the runtime session type
- Updates test fixture session factories to create SQLModel sessions (matching production), and migrates test-level `session.execute()` calls accordingly

Closes #890.

## Approach

- Per-file atomic commits so bisection is trivial if a regression slips through
- No behavioral changes. `session.exec()` returns the same data via `.one()` / `.one_or_none()` / `.all()` instead of `.scalar_one()` / `.scalar_one_or_none()` / `.scalars().all()`
- The one bulk `update(Task).where(...).values(...)` call in `router.py` (optimistic-locking task-claim path) uses SQLModel's `UpdateBase` overload on `exec()`, which returns a fully-typed `CursorResult` with `.rowcount`
- `test_resilience.py` is intentionally untouched — it creates its own sqlalchemy sessions for raw SQL manipulation, which don't go through SQLModel's wrapper

## Test plan

- [x] `uv run pytest tests/zndraw_joblib/ tests/zndraw_auth/` — 358 passed
- [x] `uv run pytest tests/zndraw/ -m "not integration"` — 1072 passed, 1 skipped
- [x] `grep -rn "session\.execute(" src/ --include="*.py"` — returns empty
- [x] `grep -rn "\.scalars(" src/ --include="*.py"` — returns empty
- [x] The `filterwarnings` gate is in effect (any `session.execute()` on a SQLModel session now fails the suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added migration plan and design specification for SQLModel query API updates across the codebase.

* **Chores**
  * Migrated database query execution methods across the application to resolve deprecation warnings and improve ORM compatibility.
  * Updated test configuration to enforce compliance with updated database query patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->